### PR TITLE
Fix/notificacoes

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -3,7 +3,7 @@ import { useWebSocket } from './useWebSocket';
 import { notificationsApi, Notificacao } from '../services/api';
 import { toast } from 'sonner';
 
-export function useNotifications(userEmail: string | undefined) {
+export function useNotifications(userEmail: string | undefined, onRefreshNeeded?: () => void) {
     const [notifications, setNotifications] = useState<Notificacao[]>([]);
     const [unreadCount, setUnreadCount] = useState(0);
 
@@ -25,16 +25,17 @@ export function useNotifications(userEmail: string | undefined) {
         toast.info(notificacao.titulo, {
             description: notificacao.mensagem,
             duration: 5000,
-            action: {
-                label: 'Ver',
-                onClick: () => {
-                    console.log('Toast Action Clicked:', notificacao.id);
-                }
-            }
         });
-    }, []);
 
-    const topic = userEmail ? `/user/${userEmail}/queue/notifications` : null;
+        // Refresh appointments after a small delay to allow backend transaction to commit
+        if (onRefreshNeeded) {
+            setTimeout(() => onRefreshNeeded(), 500);
+        }
+    }, [onRefreshNeeded]);
+
+    // In Spring, the client should always subscribe to /user/queue/... 
+    // and Spring will automatically route it using the authenticated Principal.
+    const topic = userEmail ? `/user/queue/notifications` : null;
     useWebSocket('ws://localhost:8080/ws', topic, onNotificationReceived);
 
     useEffect(() => {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Client } from '@stomp/stompjs';
+import { getCookie } from '../services/api/core/client';
 
 export function useWebSocket(
     url: string,
@@ -13,15 +14,23 @@ export function useWebSocket(
     useEffect(() => {
         if (!topic) return;
 
+        // Read JWT from cookie so the STOMP CONNECT frame is authenticated
+        const jwt = getCookie('jwt');
+        const connectHeaders: Record<string, string> = {};
+        if (jwt) {
+            connectHeaders['Authorization'] = `Bearer ${jwt}`;
+        }
+
         stompClient.current = new Client({
             brokerURL: url,
+            connectHeaders,
             reconnectDelay: 5000,
             heartbeatIncoming: 4000,
             heartbeatOutgoing: 4000,
         });
 
         stompClient.current.onConnect = () => {
-            console.log('Conectado ao WebSocket');
+            console.log('Conectado ao WebSocket (autenticado)');
             if (onConnect) onConnect();
 
             stompClient.current?.subscribe(topic, (message) => {
@@ -30,7 +39,6 @@ export function useWebSocket(
                     onMessage(parsedMessage);
                 } catch (error) {
                     console.error('Erro ao processar mensagem WS:', error);
-                    // Retornar a mensagem não formatada se não for JSON
                     onMessage(message.body);
                 }
             });

--- a/src/pages/balneario/BalnearioDashboard.tsx
+++ b/src/pages/balneario/BalnearioDashboard.tsx
@@ -37,16 +37,6 @@ export function BalnearioDashboard({ onLogout, isDarkMode, onToggleDarkMode }: B
     });
 
     const {
-        notifications,
-        unreadCount,
-        carregarNotificacoes,
-        handleMarkAsRead,
-        handleMarkAllAsRead,
-        handleDeleteNotification,
-        handleDeleteAllNotifications
-    } = useNotifications(authUser?.email);
-
-    const {
         appointments,
         loadingWeeks,
         loadWeekAppointments,
@@ -55,13 +45,36 @@ export function BalnearioDashboard({ onLogout, isDarkMode, onToggleDarkMode }: B
         getWeekKeyByDate
     } = useSlidingWindowAppointments('BALNEARIO');
 
+    // Stable wrapper for refreshCurrentWeek
+    const handleRefreshFromNotification = useCallback(() => {
+        refreshCurrentWeek(new Date());
+    }, [refreshCurrentWeek]);
+
+    const {
+        notifications,
+        unreadCount,
+        carregarNotificacoes,
+        handleMarkAsRead,
+        handleMarkAllAsRead,
+        handleDeleteNotification,
+        handleDeleteAllNotifications
+    } = useNotifications(authUser?.email, handleRefreshFromNotification);
+
     const [selectedAppointment, setSelectedAppointment] = useState<Appointment | null>(null);
     const [showAppointmentDialog, setShowAppointmentDialog] = useState(false);
     const [showDetailsDialog, setShowDetailsDialog] = useState(false);
     const [showBlockedDialog, setShowBlockedDialog] = useState(false);
     const [showDaySchedule, setShowDaySchedule] = useState<Date | null>(null);
     const [editingAppointment, setEditingAppointment] = useState<{ date: Date; time: string } | null>(null);
-    const [currentDate, setCurrentDate] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState(() => {
+        const saved = sessionStorage.getItem('balneario_currentDate');
+        return saved ? new Date(saved) : new Date();
+    });
+
+    // Persist current week view across reloads
+    useEffect(() => {
+        sessionStorage.setItem('balneario_currentDate', currentDate.toISOString());
+    }, [currentDate]);
 
     const [viewHistory, setViewHistory] = useState<ViewType[]>(() => {
         const saved = localStorage.getItem('balnearioDashboardView');

--- a/src/pages/secretary/SecretaryDashboard.tsx
+++ b/src/pages/secretary/SecretaryDashboard.tsx
@@ -40,6 +40,20 @@ interface SecretaryDashboardProps {
 export function SecretaryDashboard({ user, onLogout, isDarkMode, onToggleDarkMode }: SecretaryDashboardProps) {
   const { user: authUser, isLoading: authLoading } = useAuth();
 
+  const {
+    appointments,
+    loadingWeeks,
+    loadWeekAppointments,
+    refreshCurrentWeek,
+    updateAppointmentOptimistically,
+    getWeekKeyByDate
+  } = useSlidingWindowAppointments('SECRETARIA');
+
+  // Stable wrapper for refreshCurrentWeek (it takes a Date, but onRefreshNeeded takes no args)
+  const handleRefreshFromNotification = useCallback(() => {
+    refreshCurrentWeek(new Date());
+  }, [refreshCurrentWeek]);
+
   // Custom Hooks
   const {
     notifications,
@@ -49,16 +63,7 @@ export function SecretaryDashboard({ user, onLogout, isDarkMode, onToggleDarkMod
     handleMarkAllAsRead,
     handleDeleteNotification,
     handleDeleteAllNotifications
-  } = useNotifications(authUser?.email);
-
-  const {
-    appointments,
-    loadingWeeks,
-    loadWeekAppointments,
-    refreshCurrentWeek,
-    updateAppointmentOptimistically,
-    getWeekKeyByDate
-  } = useSlidingWindowAppointments('SECRETARIA');
+  } = useNotifications(authUser?.email, handleRefreshFromNotification);
 
   // Component States
   const [historyAppointments, setHistoryAppointments] = useState<Appointment[]>([]);
@@ -77,7 +82,15 @@ export function SecretaryDashboard({ user, onLogout, isDarkMode, onToggleDarkMod
   const [showDaySchedule, setShowDaySchedule] = useState<Date | null>(null);
   const [editingAppointment, setEditingAppointment] = useState<{ date: Date; time: string } | null>(null);
 
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const [currentDate, setCurrentDate] = useState(() => {
+    const saved = sessionStorage.getItem('secretary_currentDate');
+    return saved ? new Date(saved) : new Date();
+  });
+
+  // Persist current week view across reloads
+  useEffect(() => {
+    sessionStorage.setItem('secretary_currentDate', currentDate.toISOString());
+  }, [currentDate]);
   const [viewHistory, setViewHistory] = useState<ViewType[]>(() => {
     const saved = localStorage.getItem('secretaryDashboardView');
     return saved ? [saved as ViewType] : ['home'];

--- a/src/pages/utente/UserDashboard.tsx
+++ b/src/pages/utente/UserDashboard.tsx
@@ -54,7 +54,7 @@ export function UserDashboard({ user, onLogout, isDarkMode, onToggleDarkMode }: 
     handleMarkAllAsRead,
     handleDeleteNotification,
     handleDeleteAllNotifications
-  } = useNotifications(authUser?.email);
+  } = useNotifications(authUser?.email, refreshAppointments);
 
   // States managed locally
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -65,7 +65,15 @@ export function UserDashboard({ user, onLogout, isDarkMode, onToggleDarkMode }: 
   const [showNotifications, setShowNotifications] = useState(false);
   const [highlightedNotificationId, setHighlightedNotificationId] = useState<string | null>(null);
   const [highlightedSlot, setHighlightedSlot] = useState<{ date: Date; time: string } | null>(null);
-  const [currentDate, setCurrentDate] = useState(new Date());
+  const [currentDate, setCurrentDate] = useState(() => {
+    const saved = sessionStorage.getItem('utente_currentDate');
+    return saved ? new Date(saved) : new Date();
+  });
+
+  // Persist current week view across reloads
+  useEffect(() => {
+    sessionStorage.setItem('utente_currentDate', currentDate.toISOString());
+  }, [currentDate]);
 
   // Navigation Logic
   const getCurrentView = () => {


### PR DESCRIPTION
This pull request introduces improvements to notification handling and state persistence across the Balneario, Secretary, and User dashboards. The main changes include authenticating WebSocket connections with JWT, updating notification hooks to support automatic data refresh, and persisting the current week view in session storage to maintain user context after reloads.

**WebSocket Authentication and Notification Refresh:**

* Added JWT authentication to WebSocket connections by reading the token from cookies and passing it in the STOMP connect headers, ensuring secure and authenticated communication. (`src/hooks/useWebSocket.ts`) [[1]](diffhunk://#diff-e782b11d75b7270cd3986a3413da9bb9163747c35fa7ea567e00a7fe03dfd8cdR3) [[2]](diffhunk://#diff-e782b11d75b7270cd3986a3413da9bb9163747c35fa7ea567e00a7fe03dfd8cdR17-R33)
* Updated the `useNotifications` hook to accept an optional `onRefreshNeeded` callback, which is triggered after receiving a notification to refresh appointment data, improving real-time updates across dashboards. (`src/hooks/useNotifications.ts`) [[1]](diffhunk://#diff-0b1efe01099fae2c75b631f11f2b416b2a200c4ad467c198aa509011648a2accL6-R6) [[2]](diffhunk://#diff-0b1efe01099fae2c75b631f11f2b416b2a200c4ad467c198aa509011648a2accL25-R38)

**Dashboard Integration and State Persistence:**

* Integrated the new notification refresh logic into the Balneario, Secretary, and User dashboards by passing appropriate refresh functions to `useNotifications`, ensuring appointment data stays up-to-date after notifications. (`src/pages/balneario/BalnearioDashboard.tsx`, `src/pages/secretary/SecretaryDashboard.tsx`, `src/pages/utente/UserDashboard.tsx`) [[1]](diffhunk://#diff-1bf227ffda1ff71bd47987de4d03be20f35f0a51e90683cc62c5285afe907893L39-L48) [[2]](diffhunk://#diff-1bf227ffda1ff71bd47987de4d03be20f35f0a51e90683cc62c5285afe907893R48-R77) [[3]](diffhunk://#diff-22ba0da98ddd407319794a252a349a48e2b249650cb7275cf70ceb25027055cdR43-R56) [[4]](diffhunk://#diff-22ba0da98ddd407319794a252a349a48e2b249650cb7275cf70ceb25027055cdL52-R66) [[5]](diffhunk://#diff-de2c23a960343ad73ab6c064da460e14b904da7cb60b9295c3fdccee04c7c4a1L57-R57)
* Persisted the current week view (`currentDate`) in session storage for all dashboards, so users retain their context even after page reloads, improving usability. (`src/pages/balneario/BalnearioDashboard.tsx`, `src/pages/secretary/SecretaryDashboard.tsx`, `src/pages/utente/UserDashboard.tsx`) [[1]](diffhunk://#diff-1bf227ffda1ff71bd47987de4d03be20f35f0a51e90683cc62c5285afe907893R48-R77) [[2]](diffhunk://#diff-22ba0da98ddd407319794a252a349a48e2b249650cb7275cf70ceb25027055cdL80-R93) [[3]](diffhunk://#diff-de2c23a960343ad73ab6c064da460e14b904da7cb60b9295c3fdccee04c7c4a1L68-R76)

**Notification UI Improvements:**

* Changed notification toasts to use `toast.info` for clearer user feedback and removed the custom action button, streamlining the notification experience. (`src/hooks/useNotifications.ts`)