### PR TITLE
Fix DatePickerField to reset calendar month when no date is selected

### DIFF
--- a/src/components/ui/date-picker-field.tsx
+++ b/src/components/ui/date-picker-field.tsx
@@ -44,8 +44,10 @@ export function DatePickerField({
   useEffect(() => {
     if (selectedDate) {
       setCalendarMonth(selectedDate);
+    } else {
+      setCalendarMonth(new Date());
     }
-  }, [value]);
+  }, [selectedDate]);
 
   return (
     <Popover


### PR DESCRIPTION
This pull request introduces a small improvement to the `DatePickerField` component. The change ensures that the calendar month is reset to the current date when no date is selected, and updates the effect dependency to use `selectedDate` for more accurate state management.