### PR TITLE
Fix/logica de reserva slots

### DIFF
--- a/src/components/secretary/WeeklySchedule.tsx
+++ b/src/components/secretary/WeeklySchedule.tsx
@@ -1402,7 +1402,7 @@ export function WeeklySchedule({ appointments, allAppointments, currentUserNif, 
                     // Single-capacity slot: keep default button
                     if (slotCapacity === 1) {
                       // ...existing code for single slot...
-                      // BALNEARIO: tornar marcações sempre clicáveis para editar
+                      // BALNEARIO: tornar marcações sempre clicáveis para editar (staff), mas clientes só podem editar a sua
                       let appointmentStyles: string;
                       if (appointment?.status === 'reserved') {
                         appointmentStyles = isDarkMode
@@ -1428,8 +1428,16 @@ export function WeeklySchedule({ appointments, allAppointments, currentUserNif, 
                         }
                         return tt('Clique para editar', 'Click to edit');
                       };
-                      // Se existe marcação e não está reservada/cancelada, torna clicável para editar
-                      if (appointment && appointment.status !== 'reserved' && appointment.status !== 'cancelled') {
+                      // BALNEARIO: staff pode editar qualquer marcação, cliente só a sua
+                      if (
+                        appointment &&
+                        appointment.status !== 'reserved' &&
+                        appointment.status !== 'cancelled' &&
+                        (
+                          appointmentType !== 'BALNEARIO' ||
+                          (!isClient || ((appointment.patientNIF && currentUserNif && String(appointment.patientNIF) === String(currentUserNif)) || appointments.some(a => a.id === appointment.id)))
+                        )
+                      ) {
                         return (
                           <button
                             key={idx}
@@ -1439,7 +1447,9 @@ export function WeeklySchedule({ appointments, allAppointments, currentUserNif, 
                             className={`${base} ${appointmentStyles} ${isActiveHighlight ? 'slot-highlight' : ''}`}
                           >
                             <span className="truncate block font-semibold text-[11px] px-1 py-0.5 rounded bg-white/25 dark:bg-black/20">
-                              {appointment.patientName}
+                              {isClient && appointmentType === 'BALNEARIO' && ((appointment.patientNIF && currentUserNif && String(appointment.patientNIF) === String(currentUserNif)) || appointments.some(a => a.id === appointment.id))
+                                ? tt('Sua marcação', 'Your appointment')
+                                : appointment.patientName}
                             </span>
                           </button>
                         );


### PR DESCRIPTION
This pull request introduces several improvements and behavioral changes to the `WeeklySchedule` component, focusing on making appointment slots more interactive and user-friendly for both secretaries and clients. The main updates include ensuring appointment slots are always clickable for editing, refining the logic for rendering multi-capacity slots, and enhancing the display of reserved appointments.

**Appointment Interactivity & Editing**
- Appointment slots (especially for the "balneario" context) are now always clickable to allow editing, regardless of appointment ownership or status, except for reserved or cancelled appointments. Tooltips and button behavior have been simplified to reinforce this editability. [[1]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abR1405) [[2]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abL1415-R1416) [[3]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abL1429-R1447)

**Multi-capacity Slot Logic**
- For clients (utente), the logic for multi-capacity slots is now simplified: if the user has an appointment in the slot (and it's not reserved/cancelled/no-show), only their appointment is shown and is clickable; otherwise, the slot shows as full (non-interactive) or empty (clickable to book).
- When viewing expanded multi-capacity slots (desktop), reserved appointments are now clearly labeled and styled as "Reserved", and the add-new-appointment button is conditionally shown only when applicable.
- The display for multiple appointments in a slot now consistently handles reserved status, showing a distinct style and label for reserved slots in both single and multi-appointment scenarios. [[1]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abR1645-R1655) [[2]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abR1674-R1684)

**Slot Rendering Consistency**
- Empty multi-capacity slots now always render as a single large cell (never as mini-cells), providing a consistent UI for both secretaries and clients. [[1]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abL1608-R1746) [[2]](diffhunk://#diff-1698a5e203f38e1648b54d3f5afd92a3216c3bef625bff9158cc3ba7c073d5abL1630)

These changes collectively make the scheduling interface more intuitive and robust, especially regarding appointment editing and the handling of complex slot scenarios.

## Summary by Sourcery

Adjust WeeklySchedule slot behavior to make appointments consistently editable and improve multi-capacity slot handling and reserved-state display.

New Features:
- Allow clients in multi-capacity slots to see only their own active appointment as a clickable cell, or a clearly full/empty slot when they have no appointment.
- Add explicit reserved-state labelling and styling for appointments within multi-capacity slots, both in expanded and collapsed desktop views.

Enhancements:
- Make single-capacity balneario appointments always clickable for editing when not reserved or cancelled, with simplified tooltips.
- Ensure empty multi-capacity slots always render as a single large clickable cell instead of mini-cells for a more consistent UI.
- Show an inline add-appointment button within expanded multi-capacity slots when additional bookings are allowed.