### PR TITLE
feat: make contact field optional across registration

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -442,7 +442,8 @@
     "save": "Save",
     "saving": "Saving...",
     "cancel": "Cancel",
-    "ok": "OK"
+    "ok": "OK",
+    "optional": "(optional)"
   },
   "notifications": {
     "title": "Notifications",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -442,7 +442,8 @@
     "save": "Guardar",
     "saving": "A guardar...",
     "cancel": "Cancelar",
-    "ok": "OK"
+    "ok": "OK",
+    "optional": "(opcional)"
   },
   "notifications": {
     "title": "Notificações",

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -82,9 +82,7 @@ export function RegisterForm({ onNavigateToLogin, initialAccountType = 'user' }:
       newErrors.nif = t('auth.nifMustHave9Digits');
     }
 
-    if (!formData.contact) {
-      newErrors.contact = t('auth.contactRequired');
-    } else if (!validateContact(formData.contact)) {
+    if (formData.contact && !validateContact(formData.contact)) {
       newErrors.contact = t('auth.contactMustHave9Digits');
     }
 
@@ -324,7 +322,7 @@ export function RegisterForm({ onNavigateToLogin, initialAccountType = 'user' }:
 
           <div className="space-y-2">
             <Label htmlFor="contact" className="text-gray-700 dark:text-gray-300">
-              {t('auth.contact')} *
+              {t('auth.contact')} <span className="text-xs font-normal text-gray-500">{t('common.optional')}</span>
             </Label>
             <Input
               id="contact"

--- a/src/components/secretary/AppointmentDialog.tsx
+++ b/src/components/secretary/AppointmentDialog.tsx
@@ -254,7 +254,7 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
     } else if (!validateEmail(formData.email)) {
       newErrors.email = t('appointmentDialog.errors.emailInvalid');
     }
-    if (!validateContact(formData.contact)) {
+    if (formData.contact && !validateContact(formData.contact)) {
       newErrors.contact = t('appointmentDialog.errors.contactInvalid');
     }
 
@@ -504,7 +504,9 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="contact" className="text-gray-900 dark:text-gray-100">{t('appointmentDialog.fields.contact')}</Label>
+              <Label htmlFor="contact" className="text-gray-900 dark:text-gray-100">
+                {t('appointmentDialog.fields.contact')} <span className="text-xs font-normal text-gray-500">{t('common.optional')}</span>
+              </Label>
               <Input
                 id="contact"
                 type="text"

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -192,9 +192,7 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
         }
 
         // Contact
-        if (!formData.contact) {
-            newErrors.contact = t('auth.contactRequired');
-        } else if (!validateContact(formData.contact)) {
+        if (formData.contact && !validateContact(formData.contact)) {
             newErrors.contact = t('auth.contactMustHave9Digits');
         }
 
@@ -441,7 +439,9 @@ export function UserManagement({ isDarkMode }: UserManagementProps) {
                                             {errors.nif && <p className="text-red-500 text-xs">{errors.nif}</p>}
                                         </div>
                                         <div className="space-y-2">
-                                            <Label className="text-gray-700 dark:text-gray-300 font-medium text-xs">{t('appointmentDialog.fields.contact')}</Label>
+                                            <Label className="text-gray-700 dark:text-gray-300 font-medium text-xs">
+                                                {t('appointmentDialog.fields.contact')} <span className="font-normal opacity-70">{t('common.optional')}</span>
+                                            </Label>
                                             <Input
                                                 placeholder="912345678"
                                                 maxLength={9}


### PR DESCRIPTION
This pull request updates the handling of the "contact" field across several forms to make it optional rather than required. It also updates the UI to indicate the optional status and adds the corresponding translation strings in both English and Portuguese. The validation logic is adjusted to only validate the contact field if it is provided.

**Form validation and logic updates:**

* Changed validation for the `contact` field in `RegisterForm`, `AppointmentDialog`, and `UserManagement` components to only trigger validation if a value is provided, making the field optional. [[1]](diffhunk://#diff-947264f7deeda428e55d35f868aaa2ba47fa91241cb3e8f962bf4fdab94c2848L85-R85) [[2]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728L257-R257) [[3]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029L195-R195)

**User interface improvements:**

* Updated labels for the `contact` field in all affected forms to display an "(optional)" indicator, improving clarity for users. [[1]](diffhunk://#diff-947264f7deeda428e55d35f868aaa2ba47fa91241cb3e8f962bf4fdab94c2848L327-R325) [[2]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728L507-R509) [[3]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029L444-R444)

**Localization updates:**

* Added the "optional" string to both English and Portuguese translation files for use in form labels. [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7L445-R446) [[2]](diffhunk://#diff-f9b2e8cab2eb35ae10c58bce0b3d1270885ef9a22f32955ef41352524f7e17d7L445-R446)

## Summary by Sourcery

Make the contact field optional across registration and appointment flows while preserving validation when a value is provided.

New Features:
- Allow users to submit registration and appointment forms without providing a contact number.

Enhancements:
- Update form labels to indicate that the contact field is optional in registration, appointment, and user management views.
- Add a shared "optional" translation key for use in form labels in both English and Portuguese locales.