### PR TITLE
feat: add dark mode support to PDF report generation 

### DIFF
--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -278,18 +278,26 @@ export function HistoryPage({ appointments, onBack, onViewAppointment, isDarkMod
         <meta charset="UTF-8">
         <title>${t('history.title')}</title>
         <style>
-          body { font-family: Arial, sans-serif; margin: 20px; }
-          h1 { color: #1a202c; text-align: center; margin-bottom: 5px; }
-          .subtitle { text-align: center; color: #4a5568; margin-bottom: 20px; }
+          body { 
+            font-family: Arial, sans-serif; 
+            margin: 20px; 
+            background-color: ${isDarkMode ? '#0f172a' : '#ffffff'};
+            color: ${isDarkMode ? '#e2e8f0' : '#1e293b'};
+          }
+          h1 { color: ${isDarkMode ? '#8b5cf6' : '#7c3aed'}; text-align: center; margin-bottom: 5px; }
+          .subtitle { text-align: center; color: ${isDarkMode ? '#94a3b8' : '#4a5568'}; margin-bottom: 20px; }
           table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-          th { background-color: #4a5568; color: white; padding: 10px; text-align: left; font-size: 12px; }
-          td { padding: 8px; border-bottom: 1px solid #e2e8f0; font-size: 11px; }
-          tr:nth-child(even) { background-color: #f7fafc; }
+          th { background-color: ${isDarkMode ? '#8b5cf6' : '#7c3aed'}; color: white; padding: 10px; text-align: left; font-size: 12px; }
+          td { padding: 8px; border-bottom: 1px solid ${isDarkMode ? '#334155' : '#e2e8f0'}; font-size: 11px; }
+          tr:nth-child(even) { background-color: ${isDarkMode ? '#2e1065' : '#f5f3ff'}; }
           .status-completed { color: #38a169; font-weight: bold; }
           .status-cancelled { color: #e53e3e; }
           .status-no_show { color: #f97316; font-weight: bold; }
           .status-warning { color: #d69e2e; font-weight: bold; }
-          .footer { margin-top: 30px; text-align: center; font-size: 10px; color: #718096; }
+          .footer { margin-top: 30px; text-align: center; font-size: 10px; color: ${isDarkMode ? '#64748b' : '#718096'}; }
+          @media print {
+            body { -webkit-print-color-adjust: exact; }
+          }
         </style>
       </head>
       <body>

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -6,6 +6,7 @@ import { GlassCard } from '../../components/ui/glass-card';
 import { Button } from '../../components/ui/button';
 import { marcacoesApi } from '../../services/api/marcacoes/marcacoesApi';
 import { requisicoesApi } from '../../services/api/requisicoes/requisicoesApi';
+import { reportsApi } from '../../services/api/reports/reportsApi';
 
 // Helper to format date as YYYY-MM-DD in local time (avoids ISO timezone shift)
 const formatDate = (date: Date) => {
@@ -71,6 +72,7 @@ export function ReportsPage() {
     new Set(['secretaria', 'balneario'])
   );
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
 
   // Color palette for PDF (Fixed to Light Mode)
   const colors: Record<string, [number, number, number]> = {
@@ -90,6 +92,21 @@ export function ReportsPage() {
     if (['EM_PROGRESSO', 'EM_ANALISE', 'EM_PREENCHIMENTO', 'ENVIADA', 'URGENTE', 'ALTA'].includes(s)) return [245, 158, 11]; // Amber 600
     if (['AGENDADO', 'MEDIA'].includes(s)) return [241, 149, 217]; // #f195d9
     return [107, 114, 128]; // Gray
+  };
+
+  const getDiffDays = (isoDate?: string) => {
+    if (!isoDate) return 0;
+    const now = new Date();
+    const d = new Date(isoDate);
+    const diff = now.getTime() - d.getTime();
+    return Math.floor(diff / (1000 * 60 * 60 * 24));
+  };
+
+  const getDeadlineStyles = (days: number): { textColor?: [number, number, number], fontStyle?: 'bold', fillColor?: [number, number, number] } => {
+    if (days >= 180) return { textColor: [255, 255, 255], fillColor: [0, 0, 0], fontStyle: 'bold' };
+    if (days >= 90) return { textColor: [220, 38, 38], fontStyle: 'bold' };
+    if (days >= 30) return { textColor: [180, 83, 9], fontStyle: 'bold' }; // Darker amber for yellow
+    return { fontStyle: 'bold' };
   };
 
   const toggle = (id: ReportSection) =>
@@ -219,8 +236,17 @@ export function ReportsPage() {
         fillColor: colors.accent,
       };
 
+      let sectionCount = 0;
+
       // ── Marcações Secretaria ─────────────────────────────────────
       if (selected.has('secretaria')) {
+        if (sectionCount > 0) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        sectionCount++;
         addSectionTitle('Marcações — Secretaria', marcacoesSecretaria.length);
         if (marcacoesSecretaria.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
@@ -249,6 +275,13 @@ export function ReportsPage() {
 
       // ── Marcações Balneário ─────────────────────────────────────
       if (selected.has('balneario')) {
+        if (sectionCount > 0) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        sectionCount++;
         addSectionTitle('Marcações — Balneário', marcacoesBalneario.length);
         if (marcacoesBalneario.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
@@ -277,6 +310,13 @@ export function ReportsPage() {
 
       // ── Requisições Material ─────────────────────────────────────
       if (selected.has('material')) {
+        if (sectionCount > 0) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        sectionCount++;
         addSectionTitle('Requisições de Material', reqMaterial.length);
         if (reqMaterial.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
@@ -284,19 +324,23 @@ export function ReportsPage() {
         } else {
           autoTable(doc, {
             startY: y,
-            head: [['Data', 'Criado Por', 'Itens', 'Prioridade', 'Estado']],
-            body: reqMaterial.map(r => [
-              r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-              r.criadoPor?.nome ?? '—',
-              (r.itens ?? []).map(i => `${i.material?.nome ?? '?'} ×${i.quantidade ?? 1}`).join(', ') || '—',
-              PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-            ]),
+            head: [['Data', 'Criado Por', 'Itens', 'Prioridade', 'Duração', 'Estado']],
+            body: reqMaterial.map(r => {
+              const days = getDiffDays(r.criadoEm);
+              return [
+                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
+                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
+                (r.itens ?? []).map(i => `${i.material?.nome ?? '?'} ×${i.quantidade ?? 1}`).join(', ') || '—',
+                PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
+                { content: `${days} d`, styles: getDeadlineStyles(days) },
+                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
+              ];
+            }),
             styles: tableStyles,
             headStyles: tableHeadStyles,
             alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
-            columnStyles: { 2: { cellWidth: 60 } },
+            columnStyles: { 2: { cellWidth: 50 } },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
           });
           y = (doc as any).lastAutoTable.finalY + 10;
@@ -305,6 +349,13 @@ export function ReportsPage() {
 
       // ── Requisições Transporte ───────────────────────────────────
       if (selected.has('transporte')) {
+        if (sectionCount > 0) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        sectionCount++;
         addSectionTitle('Requisições de Transporte', reqTransporte.length);
         if (reqTransporte.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
@@ -312,15 +363,18 @@ export function ReportsPage() {
         } else {
           autoTable(doc, {
             startY: y,
-            head: [['Data', 'Criado Por', 'Destino', 'Veículo', 'Passageiros', 'Estado']],
-            body: reqTransporte.map(r => [
-              r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-              r.criadoPor?.nome ?? '—',
-              r.destino ?? '—',
-              r.transportes?.[0]?.transporte?.matricula ?? r.transporte?.matricula ?? '—',
-              r.numeroPassageiros?.toString() ?? '—',
-              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-            ]),
+            head: [['Data', 'Criado Por', 'Destino', 'Veículo', 'Duração', 'Estado']],
+            body: reqTransporte.map(r => {
+              const days = getDiffDays(r.criadoEm);
+              return [
+                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
+                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
+                r.destino ?? '—',
+                r.transportes?.[0]?.transporte?.matricula ?? r.transporte?.matricula ?? '—',
+                { content: `${days} d`, styles: getDeadlineStyles(days) },
+                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
+              ];
+            }),
             styles: tableStyles,
             headStyles: tableHeadStyles,
             alternateRowStyles: tableAlternateRowStyles,
@@ -333,6 +387,13 @@ export function ReportsPage() {
 
       // ── Requisições Manutenção ───────────────────────────────────
       if (selected.has('manutencao')) {
+        if (sectionCount > 0) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        sectionCount++;
         addSectionTitle('Requisições de Manutenção', reqManutencao.length);
         if (reqManutencao.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
@@ -340,14 +401,18 @@ export function ReportsPage() {
         } else {
           autoTable(doc, {
             startY: y,
-            head: [['Data', 'Criado Por', 'Assunto', 'Prioridade', 'Estado']],
-            body: reqManutencao.map(r => [
-              r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-              r.criadoPor?.nome ?? '—',
-              r.assunto ?? r.descricao ?? '—',
-              PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-            ]),
+            head: [['Data', 'Criado Por', 'Assunto', 'Prioridade', 'Duração', 'Estado']],
+            body: reqManutencao.map(r => {
+              const days = getDiffDays(r.criadoEm);
+              return [
+                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
+                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
+                r.assunto ?? r.descricao ?? '—',
+                PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
+                { content: `${days} d`, styles: getDeadlineStyles(days) },
+                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
+              ];
+            }),
             styles: tableStyles,
             headStyles: tableHeadStyles,
             alternateRowStyles: tableAlternateRowStyles,
@@ -497,12 +562,59 @@ export function ReportsPage() {
         </div>
       </GlassCard>
 
-      {/* Generate Button */}
-      <div className="flex justify-end">
+      {/* Actions */}
+      <div className="flex justify-end gap-3">
+        <Button
+          onClick={async () => {
+            const email = window.prompt('Introduza o e-mail de destino:');
+            if (!email) return;
+
+            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+              toast.error('E-mail inválido');
+              return;
+            }
+
+            setIsSendingEmail(true);
+            try {
+              const subject = `Relatório Institucional - Florinhas do Vouga (${startDate} a ${endDate})`;
+              const body = `Relatório institucional referente ao período de ${startDate} até ${endDate}.\n\n` +
+                `Seções selecionadas: ${Array.from(selected).map(s => SECTIONS.find(sec => sec.id === s)?.label).join(', ')}.\n\n` +
+                `Este e-mail foi gerado automaticamente pelo portal de gestão.`;
+
+              await reportsApi.sendByEmail({ to: email, subject, body });
+              toast.success('E-mail enviado com sucesso!');
+            } catch (error) {
+              toast.error('Erro ao enviar e-mail. Verifique o servidor.');
+            } finally {
+              setIsSendingEmail(false);
+            }
+          }}
+          disabled={isSendingEmail || selected.size === 0}
+          variant="outline"
+          className="border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 px-6 py-3 rounded-xl font-semibold text-sm transition-all flex items-center gap-2"
+        >
+          {isSendingEmail ? (
+            <>
+              <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              A enviar...
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              Enviar por Email
+            </>
+          )}
+        </Button>
+
         <Button
           onClick={generatePDF}
           disabled={isGenerating || selected.size === 0}
-          className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white px-8 py-3 rounded-xl shadow-lg shadow-purple-200 dark:shadow-purple-900/30 font-semibold text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          className="bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 text-white px-8 py-3 rounded-xl shadow-lg shadow-pink-200 dark:shadow-pink-900/30 font-semibold text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
         >
           {isGenerating ? (
             <>

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -16,6 +16,10 @@ const formatDate = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
+const formatDatePt = (dateStr: string) => {
+  const [year, month, day] = dateStr.split('-');
+  return `${day}/${month}/${year}`;
+};
 
 type ReportSection =
   | 'secretaria'
@@ -116,335 +120,217 @@ export function ReportsPage() {
       return next;
     });
 
-  const generatePDF = async () => {
-    if (selected.size === 0) {
-      toast.error('Selecione pelo menos um tipo de dados para incluir no relatório.');
-      return;
-    }
-    if (!startDate || !endDate) {
-      toast.error('Selecione um intervalo de datas válido.');
-      return;
+  const preparePDF = async () => {
+    const startISO = `${startDate}T00:00:00`;
+    const endISO = `${endDate}T23:59:59`;
+
+    // Parallel fetch
+    const [marcacoesSecretaria, marcacoesBalneario, requisicoes] = await Promise.all([
+      selected.has('secretaria') ? marcacoesApi.consultarAgenda(startISO, endISO, 'SECRETARIA') : Promise.resolve([]),
+      selected.has('balneario') ? marcacoesApi.consultarAgenda(startISO, endISO, 'BALNEARIO') : Promise.resolve([]),
+      (selected.has('material') || selected.has('transporte') || selected.has('manutencao'))
+        ? requisicoesApi.listar()
+        : Promise.resolve([]),
+    ]);
+
+    const startMs = new Date(startISO).getTime();
+    const endMs = new Date(endISO).getTime();
+    const filteredReqs = requisicoes.filter(r => {
+      if (!r.criadoEm) return true;
+      const t = new Date(r.criadoEm).getTime();
+      return t >= startMs && t <= endMs;
+    });
+    const reqMaterial = filteredReqs.filter(r => r.tipo === 'MATERIAL');
+    const reqTransporte = filteredReqs.filter(r => r.tipo === 'TRANSPORTE');
+    const reqManutencao = filteredReqs.filter(r => r.tipo === 'MANUTENCAO');
+
+    const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+    const pageW = doc.internal.pageSize.getWidth();
+    const pageH = doc.internal.pageSize.getHeight();
+    let y = 0;
+
+    doc.setFillColor(255, 255, 255);
+    doc.rect(0, 0, pageW, pageH, 'F');
+
+    doc.setFillColor(colors.primary[0], colors.primary[1], colors.primary[2]);
+    doc.rect(0, 0, pageW, 28, 'F');
+    doc.setTextColor(255, 255, 255);
+    doc.setFontSize(18);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Relatório Institucional', 14, 13);
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    doc.text(`Período: ${formatDatePt(startDate)} a ${formatDatePt(endDate)}`, 14, 21);
+    doc.text(`Gerado em: ${new Date().toLocaleString('pt-PT')}`, pageW - 14 - doc.getTextWidth(`Gerado em: ${new Date().toLocaleString('pt-PT')}`), 21);
+
+    y = 36;
+
+    const addSectionTitle = (title: string, count: number) => {
+      if (y > pageH - 50) {
+        doc.addPage();
+        doc.setFillColor(255, 255, 255);
+        doc.rect(0, 0, pageW, pageH, 'F');
+        y = 20;
+      }
+      doc.setFillColor(colors.accent[0], colors.accent[1], colors.accent[2]);
+      doc.roundedRect(10, y - 5, pageW - 20, 10, 2, 2, 'F');
+      doc.setTextColor(colors.primary[0], colors.primary[1], colors.primary[2]);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(11);
+      doc.text(title, 14, y + 2);
+      doc.setTextColor(120, 120, 120);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(9);
+      doc.text(`${count} registo(s)`, pageW - 14 - doc.getTextWidth(`${count} registo(s)`), y + 2);
+      y += 12;
+    };
+
+    const addFooter = (pageNum: number) => {
+      doc.setFontSize(8);
+      doc.setTextColor(160, 160, 160);
+      doc.setFont('helvetica', 'normal');
+      doc.setDrawColor(colors.border[0], colors.border[1], colors.border[2]);
+      doc.line(10, pageH - 12, pageW - 10, pageH - 12);
+      doc.text('Documento gerado automaticamente — Florinhas do Vouga', 14, pageH - 7);
+      doc.text(`Pág. ${pageNum}`, pageW - 14 - doc.getTextWidth(`Pág. ${pageNum}`), pageH - 7);
+    };
+
+    const tableStyles = { fontSize: 8, cellPadding: 2, textColor: colors.foreground, lineColor: colors.border };
+    const tableHeadStyles = { fillColor: colors.primary, textColor: 255, fontStyle: 'bold' as const };
+    const tableAlternateRowStyles = { fillColor: colors.accent };
+
+    let sectionCount = 0;
+
+    if (selected.has('secretaria')) {
+      if (sectionCount > 0) { doc.addPage(); doc.setFillColor(255, 255, 255); doc.rect(0, 0, pageW, pageH, 'F'); y = 20; }
+      sectionCount++;
+      addSectionTitle('Marcações — Secretaria', marcacoesSecretaria.length);
+      if (marcacoesSecretaria.length === 0) {
+        doc.setFontSize(9); doc.setTextColor(140, 140, 140); doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
+      } else {
+        autoTable(doc, {
+          startY: y, head: [['Data', 'Hora', 'Utente', 'Assunto', 'Tipo', 'Estado']],
+          body: marcacoesSecretaria.map(m => [formatDateStr(m.data), formatTimeStr(m.data), m.marcacaoSecretaria?.utente?.nome ?? '—', m.marcacaoSecretaria?.assunto ?? '—', m.marcacaoSecretaria?.tipoAtendimento === 'PRESENCIAL' ? 'Presencial' : 'Remota', { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } }]),
+          styles: tableStyles, headStyles: tableHeadStyles, alternateRowStyles: tableAlternateRowStyles, margin: { left: 10, right: 10 },
+          didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
+        });
+        y = (doc as any).lastAutoTable.finalY + 10;
+      }
     }
 
+    if (selected.has('balneario')) {
+      if (sectionCount > 0) { doc.addPage(); doc.setFillColor(255, 255, 255); doc.rect(0, 0, pageW, pageH, 'F'); y = 20; }
+      sectionCount++;
+      addSectionTitle('Marcações — Balneário', marcacoesBalneario.length);
+      if (marcacoesBalneario.length === 0) {
+        doc.setFontSize(9); doc.setTextColor(140, 140, 140); doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
+      } else {
+        autoTable(doc, {
+          startY: y, head: [['Data', 'Hora', 'Utente', 'Higiene', 'Lavagem', 'Estado']],
+          body: marcacoesBalneario.map(m => [formatDateStr(m.data), formatTimeStr(m.data), (m as any).marcacaoBalneario?.nomeUtente ?? '—', (m as any).marcacaoBalneario?.produtosHigiene ? 'Sim' : 'Não', (m as any).marcacaoBalneario?.lavagemRoupa ? 'Sim' : 'Não', { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } }]),
+          styles: tableStyles, headStyles: tableHeadStyles, alternateRowStyles: tableAlternateRowStyles, margin: { left: 10, right: 10 },
+          didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
+        });
+        y = (doc as any).lastAutoTable.finalY + 10;
+      }
+    }
+
+    if (selected.has('material')) {
+      if (sectionCount > 0) { doc.addPage(); doc.setFillColor(255, 255, 255); doc.rect(0, 0, pageW, pageH, 'F'); y = 20; }
+      sectionCount++;
+      addSectionTitle('Requisições de Material', reqMaterial.length);
+      if (reqMaterial.length === 0) {
+        doc.setFontSize(9); doc.setTextColor(140, 140, 140); doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
+      } else {
+        autoTable(doc, {
+          startY: y, head: [['Data', 'Criado Por', 'Itens', 'Prioridade', 'Duração', 'Estado']],
+          body: reqMaterial.map(r => { const days = getDiffDays(r.criadoEm); return [r.criadoEm ? formatDateStr(r.criadoEm) : '—', r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—', (r.itens ?? []).map(i => `${i.material?.nome ?? '?'} ×${i.quantidade ?? 1}`).join(', ') || '—', PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade, { content: `${days} d`, styles: getDeadlineStyles(days) }, { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } }]; }),
+          styles: tableStyles, headStyles: tableHeadStyles, alternateRowStyles: tableAlternateRowStyles, margin: { left: 10, right: 10 }, columnStyles: { 2: { cellWidth: 50 } },
+          didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
+        });
+        y = (doc as any).lastAutoTable.finalY + 10;
+      }
+    }
+
+    if (selected.has('transporte')) {
+      if (sectionCount > 0) { doc.addPage(); doc.setFillColor(255, 255, 255); doc.rect(0, 0, pageW, pageH, 'F'); y = 20; }
+      sectionCount++;
+      addSectionTitle('Requisições de Transporte', reqTransporte.length);
+      if (reqTransporte.length === 0) {
+        doc.setFontSize(9); doc.setTextColor(140, 140, 140); doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
+      } else {
+        autoTable(doc, {
+          startY: y, head: [['Data', 'Criado Por', 'Destino', 'Veículo', 'Duração', 'Estado']],
+          body: reqTransporte.map(r => { const days = getDiffDays(r.criadoEm); return [r.criadoEm ? formatDateStr(r.criadoEm) : '—', r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—', r.destino ?? '—', r.transportes?.[0]?.transporte?.matricula ?? r.transporte?.matricula ?? '—', { content: `${days} d`, styles: getDeadlineStyles(days) }, { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } }]; }),
+          styles: tableStyles, headStyles: tableHeadStyles, alternateRowStyles: tableAlternateRowStyles, margin: { left: 10, right: 10 },
+          didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
+        });
+        y = (doc as any).lastAutoTable.finalY + 10;
+      }
+    }
+
+    if (selected.has('manutencao')) {
+      if (sectionCount > 0) { doc.addPage(); doc.setFillColor(255, 255, 255); doc.rect(0, 0, pageW, pageH, 'F'); y = 20; }
+      sectionCount++;
+      addSectionTitle('Requisições de Manutenção', reqManutencao.length);
+      if (reqManutencao.length === 0) {
+        doc.setFontSize(9); doc.setTextColor(140, 140, 140); doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
+      } else {
+        autoTable(doc, {
+          startY: y, head: [['Data', 'Criado Por', 'Assunto', 'Prioridade', 'Duração', 'Estado']],
+          body: reqManutencao.map(r => { const days = getDiffDays(r.criadoEm); return [r.criadoEm ? formatDateStr(r.criadoEm) : '—', r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—', r.assunto ?? r.descricao ?? '—', PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade, { content: `${days} d`, styles: getDeadlineStyles(days) }, { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } }]; }),
+          styles: tableStyles, headStyles: tableHeadStyles, alternateRowStyles: tableAlternateRowStyles, margin: { left: 10, right: 10 },
+          didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
+        });
+        y = (doc as any).lastAutoTable.finalY + 10;
+      }
+    }
+
+    const totalPages = (doc as any).internal.getNumberOfPages();
+    for (let i = 1; i <= totalPages; i++) { doc.setPage(i); addFooter(i); }
+    return doc;
+  };
+
+  const generatePDF = async () => {
+    if (selected.size === 0) { toast.error('Selecione pelo menos um tipo de dados.'); return; }
+    if (!startDate || !endDate) { toast.error('Intervalo de datas inválido.'); return; }
     setIsGenerating(true);
     try {
-      const startISO = `${startDate}T00:00:00`;
-      const endISO = `${endDate}T23:59:59`;
-
-      // Parallel fetch
-      const [marcacoesSecretaria, marcacoesBalneario, requisicoes] = await Promise.all([
-        selected.has('secretaria') ? marcacoesApi.consultarAgenda(startISO, endISO, 'SECRETARIA') : Promise.resolve([]),
-        selected.has('balneario') ? marcacoesApi.consultarAgenda(startISO, endISO, 'BALNEARIO') : Promise.resolve([]),
-        (selected.has('material') || selected.has('transporte') || selected.has('manutencao'))
-          ? requisicoesApi.listar()
-          : Promise.resolve([]),
-      ]);
-
-      // Filter requisicoes by date range
-      const startMs = new Date(startISO).getTime();
-      const endMs = new Date(endISO).getTime();
-      const filteredReqs = requisicoes.filter(r => {
-        if (!r.criadoEm) return true;
-        const t = new Date(r.criadoEm).getTime();
-        return t >= startMs && t <= endMs;
-      });
-      const reqMaterial = filteredReqs.filter(r => r.tipo === 'MATERIAL');
-      const reqTransporte = filteredReqs.filter(r => r.tipo === 'TRANSPORTE');
-      const reqManutencao = filteredReqs.filter(r => r.tipo === 'MANUTENCAO');
-
-      // Create PDF
-      const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
-      const pageW = doc.internal.pageSize.getWidth();
-      const pageH = doc.internal.pageSize.getHeight();
-      let y = 0;
-
-      // White background
-      doc.setFillColor(255, 255, 255);
-      doc.rect(0, 0, pageW, pageH, 'F');
-
-      // --- Header ---
-      doc.setFillColor(colors.primary[0], colors.primary[1], colors.primary[2]);
-      doc.rect(0, 0, pageW, 28, 'F');
-      doc.setTextColor(255, 255, 255);
-      doc.setFontSize(18);
-      doc.setFont('helvetica', 'bold');
-      doc.text('Relatório Institucional', 14, 13);
-      doc.setFontSize(9);
-      doc.setFont('helvetica', 'normal');
-      doc.text(
-        `Período: ${new Date(startISO).toLocaleDateString('pt-PT')} a ${new Date(endISO).toLocaleDateString('pt-PT')}`,
-        14, 21
-      );
-      doc.text(
-        `Gerado em: ${new Date().toLocaleString('pt-PT')}`,
-        pageW - 14 - doc.getTextWidth(`Gerado em: ${new Date().toLocaleString('pt-PT')}`),
-        21
-      );
-
-      y = 36;
-
-      const addSectionTitle = (title: string, count: number) => {
-        // Check space
-        if (y > pageH - 50) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        
-        doc.setFillColor(colors.accent[0], colors.accent[1], colors.accent[2]);
-        doc.roundedRect(10, y - 5, pageW - 20, 10, 2, 2, 'F');
-        
-        doc.setTextColor(colors.primary[0], colors.primary[1], colors.primary[2]);
-        doc.setFont('helvetica', 'bold');
-        doc.setFontSize(11);
-        doc.text(title, 14, y + 2);
-        
-        doc.setTextColor(120, 120, 120);
-        doc.setFont('helvetica', 'normal');
-        doc.setFontSize(9);
-        doc.text(`${count} registo(s)`, pageW - 14 - doc.getTextWidth(`${count} registo(s)`), y + 2);
-        y += 12;
-      };
-
-      // Footer hook
-      const addFooter = (pageNum: number) => {
-        doc.setFontSize(8);
-        doc.setTextColor(160, 160, 160);
-        doc.setFont('helvetica', 'normal');
-        doc.setDrawColor(colors.border[0], colors.border[1], colors.border[2]);
-        doc.line(10, pageH - 12, pageW - 10, pageH - 12);
-        doc.text('Documento gerado automaticamente — Florinhas do Vouga', 14, pageH - 7);
-        doc.text(`Pág. ${pageNum}`, pageW - 14 - doc.getTextWidth(`Pág. ${pageNum}`), pageH - 7);
-      };
-
-      // Table settings
-      const tableStyles = {
-        fontSize: 8,
-        cellPadding: 2,
-        textColor: colors.foreground,
-        lineColor: colors.border,
-      };
-      
-      const tableHeadStyles = {
-        fillColor: colors.primary,
-        textColor: 255,
-        fontStyle: 'bold' as const,
-      };
-      
-      const tableAlternateRowStyles = {
-        fillColor: colors.accent,
-      };
-
-      let sectionCount = 0;
-
-      // ── Marcações Secretaria ─────────────────────────────────────
-      if (selected.has('secretaria')) {
-        if (sectionCount > 0) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        sectionCount++;
-        addSectionTitle('Marcações — Secretaria', marcacoesSecretaria.length);
-        if (marcacoesSecretaria.length === 0) {
-          doc.setFontSize(9); doc.setTextColor(140, 140, 140);
-          doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
-        } else {
-          autoTable(doc, {
-            startY: y,
-            head: [['Data', 'Hora', 'Utente', 'Assunto', 'Tipo', 'Estado']],
-            body: marcacoesSecretaria.map(m => [
-              formatDateStr(m.data),
-              formatTimeStr(m.data),
-              m.marcacaoSecretaria?.utente?.nome ?? '—',
-              m.marcacaoSecretaria?.assunto ?? '—',
-              m.marcacaoSecretaria?.tipoAtendimento === 'PRESENCIAL' ? 'Presencial' : 'Remota',
-              { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } },
-            ]),
-            styles: tableStyles,
-            headStyles: tableHeadStyles,
-            alternateRowStyles: tableAlternateRowStyles,
-            margin: { left: 10, right: 10 },
-            didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
-          });
-          y = (doc as any).lastAutoTable.finalY + 10;
-        }
-      }
-
-      // ── Marcações Balneário ─────────────────────────────────────
-      if (selected.has('balneario')) {
-        if (sectionCount > 0) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        sectionCount++;
-        addSectionTitle('Marcações — Balneário', marcacoesBalneario.length);
-        if (marcacoesBalneario.length === 0) {
-          doc.setFontSize(9); doc.setTextColor(140, 140, 140);
-          doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
-        } else {
-          autoTable(doc, {
-            startY: y,
-            head: [['Data', 'Hora', 'Utente', 'Higiene', 'Lavagem', 'Estado']],
-            body: marcacoesBalneario.map(m => [
-              formatDateStr(m.data),
-              formatTimeStr(m.data),
-              (m as any).marcacaoBalneario?.nomeUtente ?? '—',
-              (m as any).marcacaoBalneario?.produtosHigiene ? 'Sim' : 'Não',
-              (m as any).marcacaoBalneario?.lavagemRoupa ? 'Sim' : 'Não',
-              { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } },
-            ]),
-            styles: tableStyles,
-            headStyles: tableHeadStyles,
-            alternateRowStyles: tableAlternateRowStyles,
-            margin: { left: 10, right: 10 },
-            didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
-          });
-          y = (doc as any).lastAutoTable.finalY + 10;
-        }
-      }
-
-      // ── Requisições Material ─────────────────────────────────────
-      if (selected.has('material')) {
-        if (sectionCount > 0) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        sectionCount++;
-        addSectionTitle('Requisições de Material', reqMaterial.length);
-        if (reqMaterial.length === 0) {
-          doc.setFontSize(9); doc.setTextColor(140, 140, 140);
-          doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
-        } else {
-          autoTable(doc, {
-            startY: y,
-            head: [['Data', 'Criado Por', 'Itens', 'Prioridade', 'Duração', 'Estado']],
-            body: reqMaterial.map(r => {
-              const days = getDiffDays(r.criadoEm);
-              return [
-                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
-                (r.itens ?? []).map(i => `${i.material?.nome ?? '?'} ×${i.quantidade ?? 1}`).join(', ') || '—',
-                PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-                { content: `${days} d`, styles: getDeadlineStyles(days) },
-                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-              ];
-            }),
-            styles: tableStyles,
-            headStyles: tableHeadStyles,
-            alternateRowStyles: tableAlternateRowStyles,
-            margin: { left: 10, right: 10 },
-            columnStyles: { 2: { cellWidth: 50 } },
-            didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
-          });
-          y = (doc as any).lastAutoTable.finalY + 10;
-        }
-      }
-
-      // ── Requisições Transporte ───────────────────────────────────
-      if (selected.has('transporte')) {
-        if (sectionCount > 0) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        sectionCount++;
-        addSectionTitle('Requisições de Transporte', reqTransporte.length);
-        if (reqTransporte.length === 0) {
-          doc.setFontSize(9); doc.setTextColor(140, 140, 140);
-          doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
-        } else {
-          autoTable(doc, {
-            startY: y,
-            head: [['Data', 'Criado Por', 'Destino', 'Veículo', 'Duração', 'Estado']],
-            body: reqTransporte.map(r => {
-              const days = getDiffDays(r.criadoEm);
-              return [
-                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
-                r.destino ?? '—',
-                r.transportes?.[0]?.transporte?.matricula ?? r.transporte?.matricula ?? '—',
-                { content: `${days} d`, styles: getDeadlineStyles(days) },
-                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-              ];
-            }),
-            styles: tableStyles,
-            headStyles: tableHeadStyles,
-            alternateRowStyles: tableAlternateRowStyles,
-            margin: { left: 10, right: 10 },
-            didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
-          });
-          y = (doc as any).lastAutoTable.finalY + 10;
-        }
-      }
-
-      // ── Requisições Manutenção ───────────────────────────────────
-      if (selected.has('manutencao')) {
-        if (sectionCount > 0) {
-          doc.addPage();
-          doc.setFillColor(255, 255, 255);
-          doc.rect(0, 0, pageW, pageH, 'F');
-          y = 20;
-        }
-        sectionCount++;
-        addSectionTitle('Requisições de Manutenção', reqManutencao.length);
-        if (reqManutencao.length === 0) {
-          doc.setFontSize(9); doc.setTextColor(140, 140, 140);
-          doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
-        } else {
-          autoTable(doc, {
-            startY: y,
-            head: [['Data', 'Criado Por', 'Assunto', 'Prioridade', 'Duração', 'Estado']],
-            body: reqManutencao.map(r => {
-              const days = getDiffDays(r.criadoEm);
-              return [
-                r.criadoEm ? formatDateStr(r.criadoEm) : '—',
-                r.criadoPor?.nome ? `${r.criadoPor.nome} (${r.criadoPor.tipo ?? '?'})` : '—',
-                r.assunto ?? r.descricao ?? '—',
-                PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-                { content: `${days} d`, styles: getDeadlineStyles(days) },
-                { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
-              ];
-            }),
-            styles: tableStyles,
-            headStyles: tableHeadStyles,
-            alternateRowStyles: tableAlternateRowStyles,
-            margin: { left: 10, right: 10 },
-            didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
-          });
-          y = (doc as any).lastAutoTable.finalY + 10;
-        }
-      }
-
-      // Final pass to ensure all pages have footer and proper background
-      const totalPages = (doc as any).internal.getNumberOfPages();
-      for (let i = 1; i <= totalPages; i++) {
-        doc.setPage(i);
-        addFooter(i);
-      }
-
-      // Save
-      const filename = `relatorio_${startDate}_${endDate}.pdf`;
-      doc.save(filename);
-      toast.success(`Relatório gerado com sucesso! (${filename})`);
+      const doc = await preparePDF();
+      doc.save(`relatorio_${startDate}_${endDate}.pdf`);
+      toast.success('Relatório gerado com sucesso!');
     } catch (err) {
-      console.error('Erro ao gerar relatório:', err);
-      toast.error('Erro ao gerar o relatório. Verifique a ligação ao servidor.');
-    } finally {
-      setIsGenerating(false);
-    }
+      console.error(err);
+      toast.error('Erro ao gerar relatório.');
+    } finally { setIsGenerating(false); }
+  };
+
+  const handleSendEmail = async () => {
+    if (selected.size === 0) { toast.error('Selecione pelo menos um tipo de dados.'); return; }
+    const email = window.prompt('Introduza o e-mail de destino:');
+    if (!email) return;
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { toast.error('E-mail inválido'); return; }
+
+    setIsSendingEmail(true);
+    try {
+      const doc = await preparePDF();
+      const pdfBase64 = doc.output('datauristring');
+      const subject = `Relatório Institucional - Florinhas do Vouga (${formatDatePt(startDate)} a ${formatDatePt(endDate)})`;
+      const body = `Olá,\n\nSegue em anexo o relatório institucional referente ao período de ${formatDatePt(startDate)} até ${formatDatePt(endDate)}.\n\n` +
+        `Conteúdo do relatório:\n` +
+        Array.from(selected).map(s => `- ${SECTIONS.find(sec => sec.id === s)?.label}`).join('\n') +
+        `\n\nEste e-mail foi gerado automaticamente pelo portal de gestão.`;
+
+      await reportsApi.sendByEmail({ to: email, subject, body, pdfBase64, fileName: `relatorio_${startDate}_${endDate}.pdf` });
+      toast.success('Relatório enviado com sucesso!');
+    } catch (err) {
+      console.error(err);
+      toast.error('Erro ao enviar e-mail.');
+    } finally { setIsSendingEmail(false); }
   };
 
   return (
     <div className="max-w-4xl mx-auto space-y-6 py-2">
-      {/* Page Title */}
       <div className="flex items-center gap-3">
         <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-purple-600 to-purple-800 flex items-center justify-center shadow-lg">
           <svg className="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -457,181 +343,59 @@ export function ReportsPage() {
         </div>
       </div>
 
-      {/* Date Range */}
       <GlassCard className="p-6">
-        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center gap-2">
-          Período
-        </h2>
+        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-4">Período</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="space-y-1">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Data de Início</label>
-            <input
-              type="date"
-              value={startDate}
-              max={endDate}
-              onChange={e => setStartDate(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 transition"
-            />
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Início</label>
+            <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 outline-none" />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Data de Fim</label>
-            <input
-              type="date"
-              value={endDate}
-              min={startDate}
-              onChange={e => setEndDate(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 transition"
-            />
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Fim</label>
+            <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 outline-none" />
           </div>
         </div>
-        {/* Quick range buttons */}
-        <div className="flex flex-wrap gap-2 mt-3">
+        <div className="flex flex-wrap gap-2 mt-4">
           {[
             { label: 'Este mês', start: new Date(today.getFullYear(), today.getMonth(), 1), end: new Date(today.getFullYear(), today.getMonth() + 1, 0) },
-            { label: 'Mês passado', start: new Date(today.getFullYear(), today.getMonth() - 1, 1), end: new Date(today.getFullYear(), today.getMonth(), 0) },
-            { label: 'Últimos 7 dias', start: new Date(Date.now() - 6 * 86400000), end: today },
             { label: 'Últimos 30 dias', start: new Date(Date.now() - 29 * 86400000), end: today },
             { label: 'Este ano', start: new Date(today.getFullYear(), 0, 1), end: today },
           ].map(({ label, start, end }) => (
-            <button
-              key={label}
-              onClick={() => {
-                setStartDate(formatDate(start));
-                setEndDate(formatDate(end));
-              }}
-              className="text-xs px-3 py-1.5 rounded-full border border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 transition font-medium"
-            >
+            <button key={label} onClick={() => { setStartDate(formatDate(start)); setEndDate(formatDate(end)); }} className="text-xs px-3 py-1.5 rounded-full border border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 font-medium">
               {label}
             </button>
           ))}
         </div>
       </GlassCard>
 
-      {/* Data Types */}
       <GlassCard className="p-6">
-        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center gap-2">
-          Dados a Incluir
-        </h2>
+        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-4">Dados a Incluir</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {SECTIONS.map(section => {
             const isChecked = selected.has(section.id);
             return (
-              <button
-                key={section.id}
-                onClick={() => toggle(section.id)}
-                className={`flex items-start gap-3 p-4 rounded-xl border-2 text-left transition-all ${
-                  isChecked
-                    ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
-                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 bg-white/50 dark:bg-gray-800/30'
-                }`}
-              >
-                <div className={`mt-0.5 w-5 h-5 rounded flex-shrink-0 border-2 flex items-center justify-center transition-colors ${
-                  isChecked ? 'bg-purple-600 border-purple-600' : 'border-gray-300 dark:border-gray-500'
-                }`}>
-                  {isChecked && (
-                    <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 12 12">
-                      <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  )}
+              <button key={section.id} onClick={() => toggle(section.id)} className={`flex items-start gap-3 p-4 rounded-xl border-2 text-left transition-all ${isChecked ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20' : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 bg-white/50 dark:bg-gray-800/30'}`}>
+                <div className={`mt-0.5 w-5 h-5 rounded flex-shrink-0 border-2 flex items-center justify-center ${isChecked ? 'bg-purple-600 border-purple-600' : 'border-gray-300'}`}>
+                  {isChecked && <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 12 12"><path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>}
                 </div>
-                <div>
-                  <div className="font-medium text-sm text-gray-800 dark:text-gray-100">
-                    {section.label}
-                  </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{section.description}</div>
-                </div>
+                <div><div className="font-medium text-sm text-gray-800 dark:text-gray-100">{section.label}</div><div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{section.description}</div></div>
               </button>
             );
           })}
         </div>
-        <div className="mt-3 flex items-center gap-3">
-          <button
-            onClick={() => setSelected(new Set(SECTIONS.map(s => s.id)))}
-            className="text-xs text-purple-600 dark:text-purple-400 hover:underline"
-          >
-            Selecionar tudo
-          </button>
+        <div className="mt-4 flex items-center gap-3">
+          <button onClick={() => setSelected(new Set(SECTIONS.map(s => s.id)))} className="text-xs text-purple-600 dark:text-purple-400 hover:underline">Selecionar tudo</button>
           <span className="text-gray-300 dark:text-gray-600">|</span>
-          <button
-            onClick={() => setSelected(new Set())}
-            className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
-          >
-            Limpar seleção
-          </button>
-          <span className="ml-auto text-xs text-gray-400 dark:text-gray-500">{selected.size} de {SECTIONS.length} selecionados</span>
+          <button onClick={() => setSelected(new Set())} className="text-xs text-gray-500 dark:text-gray-400 hover:underline">Limpar seleção</button>
         </div>
       </GlassCard>
 
-      {/* Actions */}
       <div className="flex justify-end gap-3">
-        <Button
-          onClick={async () => {
-            const email = window.prompt('Introduza o e-mail de destino:');
-            if (!email) return;
-
-            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-              toast.error('E-mail inválido');
-              return;
-            }
-
-            setIsSendingEmail(true);
-            try {
-              const subject = `Relatório Institucional - Florinhas do Vouga (${startDate} a ${endDate})`;
-              const body = `Relatório institucional referente ao período de ${startDate} até ${endDate}.\n\n` +
-                `Seções selecionadas: ${Array.from(selected).map(s => SECTIONS.find(sec => sec.id === s)?.label).join(', ')}.\n\n` +
-                `Este e-mail foi gerado automaticamente pelo portal de gestão.`;
-
-              await reportsApi.sendByEmail({ to: email, subject, body });
-              toast.success('E-mail enviado com sucesso!');
-            } catch (error) {
-              toast.error('Erro ao enviar e-mail. Verifique o servidor.');
-            } finally {
-              setIsSendingEmail(false);
-            }
-          }}
-          disabled={isSendingEmail || selected.size === 0}
-          variant="outline"
-          className="border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 px-6 py-3 rounded-xl font-semibold text-sm transition-all flex items-center gap-2"
-        >
-          {isSendingEmail ? (
-            <>
-              <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              A enviar...
-            </>
-          ) : (
-            <>
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-              Enviar por Email
-            </>
-          )}
+        <Button onClick={handleSendEmail} disabled={isSendingEmail || selected.size === 0} variant="outline" className="border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/30 px-6 py-3 rounded-xl font-semibold text-sm transition-all flex items-center gap-2">
+          {isSendingEmail ? <> <svg className="animate-spin w-4 h-4" viewBox="0 0 24 24" fill="none"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg> A enviar...</> : <> <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg> Enviar por Email</>}
         </Button>
-
-        <Button
-          onClick={generatePDF}
-          disabled={isGenerating || selected.size === 0}
-          className="bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 text-white px-8 py-3 rounded-xl shadow-lg shadow-pink-200 dark:shadow-pink-900/30 font-semibold text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-        >
-          {isGenerating ? (
-            <>
-              <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              A gerar relatório…
-            </>
-          ) : (
-            <>
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              Gerar PDF
-            </>
-          )}
+        <Button onClick={generatePDF} disabled={isGenerating || selected.size === 0} className="bg-gradient-to-r from-pink-500 to-pink-600 hover:from-pink-600 hover:to-pink-700 text-white px-8 py-3 rounded-xl shadow-lg shadow-pink-200 dark:shadow-pink-900/30 font-semibold text-sm transition-all flex items-center gap-2">
+          {isGenerating ? <> <svg className="animate-spin w-4 h-4" viewBox="0 0 24 24" fill="none"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg> A gerar...</> : <> <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg> Gerar PDF</>}
         </Button>
       </div>
     </div>

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -72,6 +72,26 @@ export function ReportsPage() {
   );
   const [isGenerating, setIsGenerating] = useState(false);
 
+  // Color palette for PDF (Fixed to Light Mode)
+  const colors: Record<string, [number, number, number]> = {
+    primary: [241, 149, 217], // #f195d9
+    background: [255, 255, 255],
+    foreground: [30, 41, 59],
+    muted: [253, 242, 248], // pink-50
+    accent: [253, 242, 248], // pink-50
+    border: [251, 207, 232], // pink-200
+  };
+
+  const getStatusColor = (status?: string): [number, number, number] => {
+    if (!status) return [107, 114, 128];
+    const s = status.toUpperCase();
+    if (['CONCLUIDO', 'ACEITE', 'CONCLUIDA'].includes(s)) return [16, 185, 129]; // Emerald 600
+    if (['CANCELADO', 'RECUSADA', 'NAO_COMPARECIDO', 'INVALIDO'].includes(s)) return [220, 38, 38]; // Red 600
+    if (['EM_PROGRESSO', 'EM_ANALISE', 'EM_PREENCHIMENTO', 'ENVIADA', 'URGENTE', 'ALTA'].includes(s)) return [245, 158, 11]; // Amber 600
+    if (['AGENDADO', 'MEDIA'].includes(s)) return [241, 149, 217]; // #f195d9
+    return [107, 114, 128]; // Gray
+  };
+
   const toggle = (id: ReportSection) =>
     setSelected(prev => {
       const next = new Set(prev);
@@ -121,8 +141,12 @@ export function ReportsPage() {
       const pageH = doc.internal.pageSize.getHeight();
       let y = 0;
 
+      // White background
+      doc.setFillColor(255, 255, 255);
+      doc.rect(0, 0, pageW, pageH, 'F');
+
       // --- Header ---
-      doc.setFillColor(109, 40, 217); // purple-700
+      doc.setFillColor(colors.primary[0], colors.primary[1], colors.primary[2]);
       doc.rect(0, 0, pageW, 28, 'F');
       doc.setTextColor(255, 255, 255);
       doc.setFontSize(18);
@@ -144,34 +168,60 @@ export function ReportsPage() {
 
       const addSectionTitle = (title: string, count: number) => {
         // Check space
-        if (y > pageH - 50) { doc.addPage(); y = 20; }
-        doc.setFillColor(245, 243, 255);
+        if (y > pageH - 50) {
+          doc.addPage();
+          doc.setFillColor(255, 255, 255);
+          doc.rect(0, 0, pageW, pageH, 'F');
+          y = 20;
+        }
+        
+        doc.setFillColor(colors.accent[0], colors.accent[1], colors.accent[2]);
         doc.roundedRect(10, y - 5, pageW - 20, 10, 2, 2, 'F');
-        doc.setTextColor(109, 40, 217);
+        
+        doc.setTextColor(colors.primary[0], colors.primary[1], colors.primary[2]);
         doc.setFont('helvetica', 'bold');
         doc.setFontSize(11);
         doc.text(title, 14, y + 2);
+        
         doc.setTextColor(120, 120, 120);
         doc.setFont('helvetica', 'normal');
         doc.setFontSize(9);
-        doc.text(`${count} registro(s)`, pageW - 14 - doc.getTextWidth(`${count} registro(s)`), y + 2);
+        doc.text(`${count} registo(s)`, pageW - 14 - doc.getTextWidth(`${count} registo(s)`), y + 2);
         y += 12;
       };
 
       // Footer hook
-      const totalPagesRef = { value: 0 };
       const addFooter = (pageNum: number) => {
         doc.setFontSize(8);
         doc.setTextColor(160, 160, 160);
         doc.setFont('helvetica', 'normal');
+        doc.setDrawColor(colors.border[0], colors.border[1], colors.border[2]);
         doc.line(10, pageH - 12, pageW - 10, pageH - 12);
         doc.text('Documento gerado automaticamente — Florinhas do Vouga', 14, pageH - 7);
         doc.text(`Pág. ${pageNum}`, pageW - 14 - doc.getTextWidth(`Pág. ${pageNum}`), pageH - 7);
       };
 
+      // Table settings
+      const tableStyles = {
+        fontSize: 8,
+        cellPadding: 2,
+        textColor: colors.foreground,
+        lineColor: colors.border,
+      };
+      
+      const tableHeadStyles = {
+        fillColor: colors.primary,
+        textColor: 255,
+        fontStyle: 'bold' as const,
+      };
+      
+      const tableAlternateRowStyles = {
+        fillColor: colors.accent,
+      };
+
       // ── Marcações Secretaria ─────────────────────────────────────
       if (selected.has('secretaria')) {
-        addSectionTitle('Marcacoes — Secretaria', marcacoesSecretaria.length);
+        addSectionTitle('Marcações — Secretaria', marcacoesSecretaria.length);
         if (marcacoesSecretaria.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
           doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
@@ -185,11 +235,11 @@ export function ReportsPage() {
               m.marcacaoSecretaria?.utente?.nome ?? '—',
               m.marcacaoSecretaria?.assunto ?? '—',
               m.marcacaoSecretaria?.tipoAtendimento === 'PRESENCIAL' ? 'Presencial' : 'Remota',
-              ESTADO_LABELS[m.estado] ?? m.estado,
+              { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } },
             ]),
-            styles: { fontSize: 8, cellPadding: 2 },
-            headStyles: { fillColor: [109, 40, 217], textColor: 255, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [248, 245, 255] },
+            styles: tableStyles,
+            headStyles: tableHeadStyles,
+            alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
           });
@@ -199,7 +249,7 @@ export function ReportsPage() {
 
       // ── Marcações Balneário ─────────────────────────────────────
       if (selected.has('balneario')) {
-        addSectionTitle('Marcacoes — Balneario', marcacoesBalneario.length);
+        addSectionTitle('Marcações — Balneário', marcacoesBalneario.length);
         if (marcacoesBalneario.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
           doc.text('Sem marcações no período selecionado.', 14, y); y += 8;
@@ -213,11 +263,11 @@ export function ReportsPage() {
               (m as any).marcacaoBalneario?.nomeUtente ?? '—',
               (m as any).marcacaoBalneario?.produtosHigiene ? 'Sim' : 'Não',
               (m as any).marcacaoBalneario?.lavagemRoupa ? 'Sim' : 'Não',
-              ESTADO_LABELS[m.estado] ?? m.estado,
+              { content: ESTADO_LABELS[m.estado] ?? m.estado, styles: { textColor: getStatusColor(m.estado), fontStyle: 'bold' } },
             ]),
-            styles: { fontSize: 8, cellPadding: 2 },
-            headStyles: { fillColor: [8, 145, 178], textColor: 255, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [240, 249, 255] },
+            styles: tableStyles,
+            headStyles: tableHeadStyles,
+            alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
           });
@@ -227,7 +277,7 @@ export function ReportsPage() {
 
       // ── Requisições Material ─────────────────────────────────────
       if (selected.has('material')) {
-        addSectionTitle('Requisicoes de Material', reqMaterial.length);
+        addSectionTitle('Requisições de Material', reqMaterial.length);
         if (reqMaterial.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
           doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
@@ -240,11 +290,11 @@ export function ReportsPage() {
               r.criadoPor?.nome ?? '—',
               (r.itens ?? []).map(i => `${i.material?.nome ?? '?'} ×${i.quantidade ?? 1}`).join(', ') || '—',
               PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-              ESTADO_LABELS[r.estado] ?? r.estado,
+              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
             ]),
-            styles: { fontSize: 8, cellPadding: 2 },
-            headStyles: { fillColor: [234, 88, 12], textColor: 255, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [255, 247, 237] },
+            styles: tableStyles,
+            headStyles: tableHeadStyles,
+            alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
             columnStyles: { 2: { cellWidth: 60 } },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
@@ -255,7 +305,7 @@ export function ReportsPage() {
 
       // ── Requisições Transporte ───────────────────────────────────
       if (selected.has('transporte')) {
-        addSectionTitle('Requisicoes de Transporte', reqTransporte.length);
+        addSectionTitle('Requisições de Transporte', reqTransporte.length);
         if (reqTransporte.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
           doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
@@ -269,11 +319,11 @@ export function ReportsPage() {
               r.destino ?? '—',
               r.transportes?.[0]?.transporte?.matricula ?? r.transporte?.matricula ?? '—',
               r.numeroPassageiros?.toString() ?? '—',
-              ESTADO_LABELS[r.estado] ?? r.estado,
+              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
             ]),
-            styles: { fontSize: 8, cellPadding: 2 },
-            headStyles: { fillColor: [22, 163, 74], textColor: 255, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [240, 253, 244] },
+            styles: tableStyles,
+            headStyles: tableHeadStyles,
+            alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
           });
@@ -283,7 +333,7 @@ export function ReportsPage() {
 
       // ── Requisições Manutenção ───────────────────────────────────
       if (selected.has('manutencao')) {
-        addSectionTitle('Requisicoes de Manutencao', reqManutencao.length);
+        addSectionTitle('Requisições de Manutenção', reqManutencao.length);
         if (reqManutencao.length === 0) {
           doc.setFontSize(9); doc.setTextColor(140, 140, 140);
           doc.text('Sem requisições no período selecionado.', 14, y); y += 8;
@@ -296,11 +346,11 @@ export function ReportsPage() {
               r.criadoPor?.nome ?? '—',
               r.assunto ?? r.descricao ?? '—',
               PRIORIDADE_LABELS[r.prioridade] ?? r.prioridade,
-              ESTADO_LABELS[r.estado] ?? r.estado,
+              { content: ESTADO_LABELS[r.estado] ?? r.estado, styles: { textColor: getStatusColor(r.estado), fontStyle: 'bold' } },
             ]),
-            styles: { fontSize: 8, cellPadding: 2 },
-            headStyles: { fillColor: [100, 116, 139], textColor: 255, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [248, 250, 252] },
+            styles: tableStyles,
+            headStyles: tableHeadStyles,
+            alternateRowStyles: tableAlternateRowStyles,
             margin: { left: 10, right: 10 },
             didDrawPage: (data) => { addFooter(data.pageNumber); y = data.cursor?.y ?? y; },
           });
@@ -308,13 +358,12 @@ export function ReportsPage() {
         }
       }
 
-      // Add footer to last page
+      // Final pass to ensure all pages have footer and proper background
       const totalPages = (doc as any).internal.getNumberOfPages();
       for (let i = 1; i <= totalPages; i++) {
         doc.setPage(i);
         addFooter(i);
       }
-      totalPagesRef.value = totalPages;
 
       // Save
       const filename = `relatorio_${startDate}_${endDate}.pdf`;

--- a/src/services/api/reports/reportsApi.ts
+++ b/src/services/api/reports/reportsApi.ts
@@ -1,0 +1,15 @@
+import { apiRequest } from '../core/client';
+
+export interface SendReportRequest {
+  to: String;
+  subject: String;
+  body: String;
+}
+
+export const reportsApi = {
+  sendByEmail: (payload: SendReportRequest) =>
+    apiRequest<void>('/api/reports/email', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+};

--- a/src/services/api/reports/reportsApi.ts
+++ b/src/services/api/reports/reportsApi.ts
@@ -4,6 +4,8 @@ export interface SendReportRequest {
   to: String;
   subject: String;
   body: String;
+  pdfBase64?: String;
+  fileName?: String;
 }
 
 export const reportsApi = {


### PR DESCRIPTION
This pull request updates the PDF export and print styling for the History and Reports pages, focusing on consistent theming, improved color usage, and minor textual corrections. The main changes involve unifying the color palette for generated PDFs (now always using a light mode palette), improving table and section styling, and applying dynamic status coloring for better readability. Additionally, some Portuguese language corrections and minor UI/UX improvements have been made.

**PDF Export and Styling Improvements**

* Introduced a centralized color palette for PDF generation in `ReportsPage`, ensuring all sections and tables use consistent light mode colors. Table styles, header styles, and alternate row styles are now defined in shared variables for maintainability. [[1]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5R75-R94) [[2]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L147-R224)
* All table status cells now use dynamic coloring based on their status, improving readability and visual cues for users. [[1]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L188-R242) [[2]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L216-R270) [[3]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L243-R297) [[4]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L272-R326) [[5]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L299-L317)
* Section titles, table headers, and alternate row backgrounds in the PDF are now consistently styled using the new color palette.
* The PDF export now ensures every page has a white background and a consistent footer, regardless of content. [[1]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5R144-R149) [[2]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L299-L317)

**Language and Usability Enhancements**

* Corrected Portuguese spelling and improved section titles (e.g., "Marcações", "Requisições") for clarity and consistency. [[1]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L188-R242) [[2]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L202-R252) [[3]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L230-R280) [[4]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L258-R308) [[5]](diffhunk://#diff-45fd7e27491288e874a5f9967ec74c275cfb28c038a1e7036ce9c478f00e4be5L286-R336)
* Updated the print/export stylesheet in `HistoryPage` to support dark mode, changing background and text colors dynamically based on the current theme.

## Summary by Sourcery

Update report generation to use a unified light-theme PDF layout, add email delivery for generated reports, and align history printing with the active dark or light theme.

New Features:
- Allow institutional reports to be sent by email directly from the Reports page with generated PDF attachments.
- Introduce duration and enhanced metadata columns in report tables for material, transport, and maintenance requests.
- Add dark-mode-aware styling to the History page print/PDF output.

Enhancements:
- Unify PDF report styling with a centralized light color palette, consistent headers, footers, and section layouts across all report types.
- Apply status-based coloring and deadline highlighting in PDF tables to improve readability and prioritization.
- Refine Labels, Portuguese wording, and selection controls on the Reports page for clearer UX.