### PR TITLE
Feat/requisicoes periodicas

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -783,8 +783,8 @@
         "MENSAL": "Monthly"
       },
       "dataInicio": "Start Date",
-      "dataFim": "End Date",
-      "dataFimHint": "Optional. Maximum date.",
+      "dataFim": "End Date (Optional)",
+      "dataFimHint": "Select date",
       "errors": {
         "dataInicioRequired": "Start date is mandatory for this frequency."
       }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -786,7 +786,7 @@
       "dataFim": "End Date (Optional)",
       "dataFimHint": "Select date",
       "errors": {
-        "dataInicioRequired": "Start date is mandatory for this frequency."
+        "dataInicioRequired": "Start date is mandatory for periodic requests."
       }
     },
     "summary": "{{total}} request(s) · {{urgent}} urgent",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -774,6 +774,21 @@
     }
   },
   "requisitions": {
+    "periodica": {
+      "label": "Periodic Request",
+      "frequencia": {
+        "label": "Frequency",
+        "DIARIA": "Daily",
+        "SEMANAL": "Weekly",
+        "MENSAL": "Monthly"
+      },
+      "dataInicio": "Start Date",
+      "dataFim": "End Date",
+      "dataFimHint": "Optional. Maximum date.",
+      "errors": {
+        "dataInicioRequired": "Start date is mandatory for this frequency."
+      }
+    },
     "summary": "{{total}} request(s) · {{urgent}} urgent",
     "labels": {
       "allStatuses": "All statuses",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -777,6 +777,21 @@
     }
   },
   "requisitions": {
+    "periodica": {
+      "label": "Requisição Periódica",
+      "frequencia": {
+        "label": "Frequência",
+        "DIARIA": "Diária",
+        "SEMANAL": "Semanal",
+        "MENSAL": "Mensal"
+      },
+      "dataInicio": "Data de Início",
+      "dataFim": "Data de Fim",
+      "dataFimHint": "Opcional. Data máxima.",
+      "errors": {
+        "dataInicioRequired": "A data de início é obrigatória para esta frequência."
+      }
+    },
     "summary": "{{total}} requisição(ões) · {{urgent}} urgente(s)",
     "labels": {
       "allStatuses": "Todos os estados",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -786,8 +786,8 @@
         "MENSAL": "Mensal"
       },
       "dataInicio": "Data de Início",
-      "dataFim": "Data de Fim",
-      "dataFimHint": "Opcional. Data máxima.",
+      "dataFim": "Data de Fim (Opcional)",
+      "dataFimHint": "Selecionar data",
       "errors": {
         "dataInicioRequired": "A data de início é obrigatória para esta frequência."
       }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -789,7 +789,7 @@
       "dataFim": "Data de Fim (Opcional)",
       "dataFimHint": "Selecionar data",
       "errors": {
-        "dataInicioRequired": "A data de início é obrigatória para esta frequência."
+        "dataInicioRequired": "A data de início é obrigatória para requisições periódicas."
       }
     },
     "summary": "{{total}} requisição(ões) · {{urgent}} urgente(s)",

--- a/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
+++ b/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
@@ -1,6 +1,21 @@
 import { Textarea } from '../../ui/textarea';
+import { Checkbox } from '../../ui/checkbox';
+import { DatePickerField } from '../../ui/date-picker-field';
 import { RequisicaoPrioridade, RequisicaoTipo } from '../../../services/api';
 import { PRIORIDADE_OPTIONS, TIPO_OPTIONS } from '../../../pages/requisitions/sharedRequisitions.helpers';
+import { PeriodicidadeFrequencia } from '../../../services/api/requisicoes/types';
+
+/* 
+i18n keys needed (inform only):
+requisitions.periodica.label
+requisitions.periodica.frequencia.label
+requisitions.periodica.frequencia.DIARIA
+requisitions.periodica.frequencia.SEMANAL
+requisitions.periodica.frequencia.MENSAL
+requisitions.periodica.dataInicio
+requisitions.periodica.dataFim
+requisitions.periodica.dataFimHint
+*/
 
 interface RequisitionsCreateCommonFieldsProps {
   descricao: string;
@@ -8,6 +23,14 @@ interface RequisitionsCreateCommonFieldsProps {
   onChangeTipo: (value: RequisicaoTipo) => void;
   prioridade: RequisicaoPrioridade;
   onChangePrioridade: (value: RequisicaoPrioridade) => void;
+  isPeriodica: boolean;
+  onChangeIsPeriodica: (value: boolean) => void;
+  periodicaFrequencia: PeriodicidadeFrequencia;
+  onChangePeriodicaFrequencia: (value: PeriodicidadeFrequencia) => void;
+  periodicaDataInicio: string;
+  onChangePeriodicaDataInicio: (value: string) => void;
+  periodicaDataFim: string;
+  onChangePeriodicaDataFim: (value: string) => void;
   tipo: RequisicaoTipo;
   descricaoError?: string;
   inputFieldClassName: string;
@@ -23,6 +46,14 @@ export function RequisitionsCreateCommonFields({
   onChangeTipo,
   prioridade,
   onChangePrioridade,
+  isPeriodica,
+  onChangeIsPeriodica,
+  periodicaFrequencia,
+  onChangePeriodicaFrequencia,
+  periodicaDataInicio,
+  onChangePeriodicaDataInicio,
+  periodicaDataFim,
+  onChangePeriodicaDataFim,
   descricaoError,
   textareaFieldClassName,
   selectFieldClassName,
@@ -71,6 +102,61 @@ export function RequisitionsCreateCommonFields({
           rows={3}
         />
         {descricaoError && <p className="text-status-error text-xs mt-1">{descricaoError}</p>}
+      </div>
+
+      <div className="pt-2 border-t mt-4 border-input-border/30">
+        <label className="flex items-center space-x-2 text-sm font-medium cursor-pointer">
+          <Checkbox
+            checked={isPeriodica}
+            onCheckedChange={(checked) => onChangeIsPeriodica(checked === true)}
+          />
+          <span>{t('requisitions.periodica.label')}</span>
+        </label>
+
+        {isPeriodica && (
+          <div className="grid grid-cols-1 gap-3 mt-3 sm:grid-cols-3">
+            <div>
+              <label htmlFor="req-periodica-frequencia" className="text-sm text-muted-foreground">
+                {t('requisitions.periodica.frequencia.label')}
+              </label>
+              <select
+                id="req-periodica-frequencia"
+                value={periodicaFrequencia}
+                onChange={(e) => onChangePeriodicaFrequencia(e.target.value as PeriodicidadeFrequencia)}
+                className={selectFieldClassName}
+              >
+                <option value="DIARIA">{t('requisitions.periodica.frequencia.DIARIA')}</option>
+                <option value="SEMANAL">{t('requisitions.periodica.frequencia.SEMANAL')}</option>
+                <option value="MENSAL">{t('requisitions.periodica.frequencia.MENSAL')}</option>
+              </select>
+            </div>
+            
+            <div>
+              <label htmlFor="req-periodica-dataInicio" className="text-sm text-muted-foreground">
+                {t('requisitions.periodica.dataInicio')}
+              </label>
+              <DatePickerField
+                id="req-periodica-dataInicio"
+                value={periodicaDataInicio}
+                onChange={onChangePeriodicaDataInicio}
+                buttonClassName={inputFieldClassName}
+              />
+            </div>
+            
+            <div>
+              <label htmlFor="req-periodica-dataFim" className="text-sm text-muted-foreground">
+                {t('requisitions.periodica.dataFim')}
+              </label>
+              <DatePickerField
+                id="req-periodica-dataFim"
+                value={periodicaDataFim}
+                onChange={onChangePeriodicaDataFim}
+                placeholder={t('requisitions.periodica.dataFimHint')}
+                buttonClassName={inputFieldClassName}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
+++ b/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
@@ -54,8 +54,7 @@ export function RequisitionsCreateCommonFields({
   onChangePeriodicaDataInicio,
   periodicaDataFim,
   onChangePeriodicaDataFim,
-  descricaoError,
-  textareaFieldClassName,
+  descricaoError,  inputFieldClassName,  textareaFieldClassName,
   selectFieldClassName,
   t,
 }: Readonly<RequisitionsCreateCommonFieldsProps>) {

--- a/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
+++ b/src/components/shared/requisitions/RequisitionsCreateCommonFields.tsx
@@ -5,18 +5,6 @@ import { RequisicaoPrioridade, RequisicaoTipo } from '../../../services/api';
 import { PRIORIDADE_OPTIONS, TIPO_OPTIONS } from '../../../pages/requisitions/sharedRequisitions.helpers';
 import { PeriodicidadeFrequencia } from '../../../services/api/requisicoes/types';
 
-/* 
-i18n keys needed (inform only):
-requisitions.periodica.label
-requisitions.periodica.frequencia.label
-requisitions.periodica.frequencia.DIARIA
-requisitions.periodica.frequencia.SEMANAL
-requisitions.periodica.frequencia.MENSAL
-requisitions.periodica.dataInicio
-requisitions.periodica.dataFim
-requisitions.periodica.dataFimHint
-*/
-
 interface RequisitionsCreateCommonFieldsProps {
   descricao: string;
   onChangeDescricao: (value: string) => void;

--- a/src/hooks/requisitions/useRequisitionCreateForm.ts
+++ b/src/hooks/requisitions/useRequisitionCreateForm.ts
@@ -1,12 +1,18 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { RequisicaoPrioridade, RequisicaoTipo } from '../../services/api';
 import { CreateField } from '../../pages/requisitions/sharedRequisitions.helpers';
-import { MaterialCategoria } from '../../services/api/requisicoes/types';
+import { MaterialCategoria, PeriodicidadeFrequencia, RequisicaoPeriodicaConfig } from '../../services/api/requisicoes/types';
 
 export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPrioridade?: RequisicaoPrioridade) {
   const [tipo, setTipo] = useState<RequisicaoTipo>(initialTipo ?? 'MATERIAL');
   const [descricao, setDescricao] = useState('');
   const [prioridade, setPrioridade] = useState<RequisicaoPrioridade>(initialPrioridade ?? 'MEDIA');
+  
+  // Periodicidade state
+  const [isPeriodica, setIsPeriodica] = useState(false);
+  const [periodicaFrequencia, setPeriodicaFrequencia] = useState<PeriodicidadeFrequencia>('SEMANAL');
+  const [periodicaDataInicio, setPeriodicaDataInicio] = useState('');
+  const [periodicaDataFim, setPeriodicaDataFim] = useState('');
   
   const [createErrors, setCreateErrors] = useState<Partial<Record<CreateField, string>>>({});
   const [createTouched, setCreateTouched] = useState<Partial<Record<CreateField, boolean>>>({});
@@ -51,6 +57,10 @@ export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPr
 
   const resetForm = useCallback(() => {
     setDescricao('');
+    setIsPeriodica(false);
+    setPeriodicaFrequencia('SEMANAL');
+    setPeriodicaDataInicio('');
+    setPeriodicaDataFim('');
     setMaterialLinhas([]);
     setDestinoTransporte('');
     setDataSaida('');
@@ -128,6 +138,7 @@ export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPr
       tipo !== (initialTipo ?? 'MATERIAL') ||
       prioridade !== (initialPrioridade ?? 'MEDIA') ||
       descricao !== '' ||
+      isPeriodica !== false ||
       materialLinhas.length > 0 ||
       destinoTransporte !== '' ||
       dataSaida !== '' ||
@@ -146,6 +157,7 @@ export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPr
     prioridade,
     initialPrioridade,
     descricao,
+    isPeriodica,
     materialLinhas,
     destinoTransporte,
     dataSaida,
@@ -159,6 +171,16 @@ export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPr
     manutencaoObservacoesPorCategoria,
   ]);
 
+
+  const periodicaConfig = useMemo((): RequisicaoPeriodicaConfig | null => {
+    if (!isPeriodica || !periodicaDataInicio) return null;
+    return {
+      frequencia: periodicaFrequencia,
+      dataInicio: periodicaDataInicio,
+      dataFim: periodicaDataFim || null,
+    };
+  }, [isPeriodica, periodicaFrequencia, periodicaDataInicio, periodicaDataFim]);
+
   return {
     // General form state
     tipo,
@@ -167,6 +189,15 @@ export function useRequisitionCreateForm(initialTipo?: RequisicaoTipo, initialPr
     setDescricao,
     prioridade,
     setPrioridade,
+    isPeriodica,
+    setIsPeriodica,
+    periodicaFrequencia,
+    setPeriodicaFrequencia,
+    periodicaDataInicio,
+    setPeriodicaDataInicio,
+    periodicaDataFim,
+    setPeriodicaDataFim,
+    periodicaConfig,
     isDirty,
     // Validation
     createErrors,

--- a/src/pages/requisitions/SharedRequisitionsPage.tsx
+++ b/src/pages/requisitions/SharedRequisitionsPage.tsx
@@ -776,6 +776,11 @@ export function SharedRequisitionsPage({
       return;
     }
 
+    if (createForm.isPeriodica && !createForm.periodicaDataInicio) {
+      toast.error(t('requisitions.periodica.errors.dataInicioRequired'));
+      return;
+    }
+
     setIsConfirmModalOpen(true);
   }, [currentUserId, createForm, validateAndSetField, t]);
 
@@ -789,6 +794,7 @@ export function SharedRequisitionsPage({
       const payloadBase = {
         descricao: createForm.descricao.trim() || undefined,
         prioridade: createForm.prioridade,
+        periodica: createForm.periodicaConfig,
       };
 
       if (createForm.tipo === 'MATERIAL') {
@@ -1321,6 +1327,14 @@ export function SharedRequisitionsPage({
           onChangeTipo={createForm.setTipo}
           prioridade={createForm.prioridade}
           onChangePrioridade={createForm.setPrioridade}
+          isPeriodica={createForm.isPeriodica}
+          onChangeIsPeriodica={createForm.setIsPeriodica}
+          periodicaFrequencia={createForm.periodicaFrequencia}
+          onChangePeriodicaFrequencia={createForm.setPeriodicaFrequencia}
+          periodicaDataInicio={createForm.periodicaDataInicio}
+          onChangePeriodicaDataInicio={createForm.setPeriodicaDataInicio}
+          periodicaDataFim={createForm.periodicaDataFim}
+          onChangePeriodicaDataFim={createForm.setPeriodicaDataFim}
           descricaoError={createForm.createErrors.descricao}
           inputFieldClassName={inputFieldClassName}
           textareaFieldClassName={textareaFieldClassName}

--- a/src/pages/requisitions/SharedRequisitionsPage.tsx
+++ b/src/pages/requisitions/SharedRequisitionsPage.tsx
@@ -794,7 +794,7 @@ export function SharedRequisitionsPage({
       const payloadBase = {
         descricao: createForm.descricao.trim() || undefined,
         prioridade: createForm.prioridade,
-        periodica: createForm.periodicaConfig,
+        ...(createForm.periodicaConfig != null ? { periodica: createForm.periodicaConfig } : {}),
       };
 
       if (createForm.tipo === 'MATERIAL') {

--- a/src/services/api/requisicoes/types.ts
+++ b/src/services/api/requisicoes/types.ts
@@ -138,10 +138,19 @@ export interface RequisicaoFilters {
   dataFim?: string;
 }
 
+export type PeriodicidadeFrequencia = 'DIARIA' | 'SEMANAL' | 'MENSAL';
+
+export interface RequisicaoPeriodicaConfig {
+  frequencia: PeriodicidadeFrequencia;
+  dataInicio: string;
+  dataFim?: string | null;
+}
+
 export interface CriarRequisicaoBaseRequest {
   descricao?: string;
   prioridade: RequisicaoPrioridade;
   geridoPorId?: number;
+  periodica?: RequisicaoPeriodicaConfig | null;
 }
 
 export interface CriarRequisicaoMaterialRequest extends CriarRequisicaoBaseRequest {


### PR DESCRIPTION
This pull request introduces support for creating periodic requisitions, allowing users to specify a frequency, start date, and optional end date for their requests. The implementation includes UI changes, new form state management, validation, and updates to the API payload. Additionally, new internationalization (i18n) strings are added for both English and Portuguese.

**Periodic requisition support:**

* Added new UI fields to `RequisitionsCreateCommonFields.tsx` for enabling periodic requisitions, selecting frequency (`DIARIA`, `SEMANAL`, `MENSAL`), and picking start/end dates. These fields are conditionally displayed when the periodic option is selected. [[1]](diffhunk://#diff-b976fc5677e179dc42b73f136818200f075ce62ad029803a8d5710f3db40f983R2-R33) [[2]](diffhunk://#diff-b976fc5677e179dc42b73f136818200f075ce62ad029803a8d5710f3db40f983L26-R57) [[3]](diffhunk://#diff-b976fc5677e179dc42b73f136818200f075ce62ad029803a8d5710f3db40f983R105-R159)
* Extended the form state in `useRequisitionCreateForm` to manage periodic requisition data, including state variables, reset logic, and a computed config object (`periodicaConfig`). [[1]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35L4-R16) [[2]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35R60-R63) [[3]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35R141) [[4]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35R160) [[5]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35R174-R183) [[6]](diffhunk://#diff-f1f17877161d01003de9b6d34306c9edff484c839206c9eb6709fe04a6f1cb35R192-R200)
* Updated the requisition creation flow in `SharedRequisitionsPage.tsx` to validate the presence of a start date for periodic requests and to include the periodic config in the API payload. [[1]](diffhunk://#diff-f757325c01b3b95c753275edef315ea08a344b3ec12a67f67fb5444e03cdaa68R779-R783) [[2]](diffhunk://#diff-f757325c01b3b95c753275edef315ea08a344b3ec12a67f67fb5444e03cdaa68R797) [[3]](diffhunk://#diff-f757325c01b3b95c753275edef315ea08a344b3ec12a67f67fb5444e03cdaa68R1330-R1337)

**API and type updates:**

* Added new types `PeriodicidadeFrequencia` and `RequisicaoPeriodicaConfig` to the API types file, and extended the requisition creation request interface to support the periodic config.

**Internationalization:**

* Added new i18n strings for periodic requisition fields and errors in both English (`en.json`) and Portuguese (`pt.json`). [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7R777-R791) [[2]](diffhunk://#diff-f9b2e8cab2eb35ae10c58bce0b3d1270885ef9a22f32955ef41352524f7e17d7R780-R794)

## Summary by Sourcery

Add support for creating periodic requisitions with configurable frequency and dates, wiring the new form state into the creation flow and API payload.

New Features:
- Introduce UI controls to mark a requisition as periodic, select its frequency, and define start and optional end dates.
- Extend the requisition creation form hook to manage periodicity state and expose a computed periodic configuration for submissions.
- Include periodic requisition configuration in the requisition creation API request and ensure start date validation in the creation flow.

Enhancements:
- Add typed API models for periodic requisition configuration and frequency values.
- Extend requisition i18n resources to cover periodic requisition labels, options, and validation errors in supported languages.