### PR TITLE
fix: mask NIF in all display contexts (M6)

### DIFF
--- a/src/components/secretary/AppointmentDetailsDialog.tsx
+++ b/src/components/secretary/AppointmentDetailsDialog.tsx
@@ -12,6 +12,7 @@ import { Input } from '../ui/input';
 import { toast } from 'sonner';
 import { XIcon, FileTextIcon, AlertTriangleIcon, UserIcon, ClockIcon, PhoneIcon, MailIcon, BellIcon, MenuIcon } from '../shared/CustomIcons';
 import { Download, Trash2, Upload } from 'lucide-react';
+import { maskNif } from '../../utils/maskNif';
 
 // EyeIcon SVG inline (usado para preview)
 function EyeIcon({ className }: { className?: string }) {
@@ -644,7 +645,7 @@ export function AppointmentDetailsDialog({
             <div className="grid grid-cols-2 gap-4">
               <div className="bg-muted/50 rounded-lg p-4 border border-border">
                 <Label className="text-sm mb-2"># NIF</Label>
-                <p className="text-foreground">{appointment.patientNIF}</p>
+                <p className="text-foreground">{maskNif(appointment.patientNIF)}</p>
               </div>
 
               <div className="bg-muted/50 rounded-lg p-4 border border-border">

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -1123,7 +1123,7 @@ export function UserManagement() {
                                     </div>
                                     <div className="flex items-center gap-1.5">
                                         <Lock className="w-3.5 h-3.5" />
-                                        {editForm.nif}
+                                        {maskNif(editForm.nif)}
                                     </div>
                                 </div>
                             </div>
@@ -1424,7 +1424,7 @@ export function UserManagement() {
                     <AlertDialogHeader>
                         <AlertDialogTitle>Anonimizar e Eliminar Utilizador?</AlertDialogTitle>
                         <AlertDialogDescription className="text-muted-foreground">
-                            Está prestes a <strong>anonimizar e eliminar permanentemente</strong> o utilizador <strong>{selectedUser?.nome}</strong> (NIF: {selectedUser?.nif}).
+                            Está prestes a <strong>anonimizar e eliminar permanentemente</strong> o utilizador <strong>{selectedUser?.nome}</strong> (NIF: {maskNif(selectedUser?.nif)}).
                             <br /><br />
                             <strong>Esta ação irá:</strong>
                             <ul className="list-disc list-inside mt-2 space-y-1">

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -1374,7 +1374,7 @@ export function UserManagement() {
                     <AlertDialogHeader>
                         <AlertDialogTitle>{t('userManagement.userAlreadyExistsTitle')}</AlertDialogTitle>
                         <AlertDialogDescription className="text-muted-foreground">
-                            {t('userManagement.userAlreadyExistsDescription', { nif: existingUserForDialog?.nif })}
+                            {t('userManagement.userAlreadyExistsDescription', { nif: maskNif(existingUserForDialog?.nif) })}
                             <br /><br />
                             <strong>{t('requisitions.ui.name')}:</strong> {existingUserForDialog?.nome}
                             <br />


### PR DESCRIPTION
- AppointmentDetailsDialog: import maskNif and apply to patientNIF display
- UserManagement: apply maskNif to editForm.nif display and delete confirmation dialog
- WeeklySchedule already used maskNif correctly

## Summary by Sourcery

Mask NIF identifiers in all remaining user-facing displays for appointments and user management to ensure consistent anonymization.

Bug Fixes:
- Apply NIF masking to the user edit form and delete confirmation dialog in UserManagement.
- Apply NIF masking to the patient NIF display in AppointmentDetailsDialog.