### PR TITLE
fix: remove sensitive user data from localStorage (M8)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -174,7 +174,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setUser(userData);
     setIsAuthenticated(true);
 
-    localStorage.setItem('lastActivity', Date.now().toString()); // Only non-sensitive activity timestamp
+    updateActivity();
+    localStorage.removeItem('user'); // Remove legacy sensitive data from older versions
 
     // Clear legacy dashboard views
     localStorage.removeItem('userDashboardView');
@@ -184,7 +185,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const handleLogoutState = () => {
     setUser(null);
     setIsAuthenticated(false);
-    localStorage.removeItem('user');
     localStorage.removeItem('lastActivity');
     localStorage.removeItem('token'); // Clear legacy token if exists
   };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -174,8 +174,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setUser(userData);
     setIsAuthenticated(true);
 
-    localStorage.setItem('user', JSON.stringify(userData)); // Optional: cache user info, but NOT token
-    localStorage.setItem('lastActivity', Date.now().toString());
+    localStorage.setItem('lastActivity', Date.now().toString()); // Only non-sensitive activity timestamp
 
     // Clear legacy dashboard views
     localStorage.removeItem('userDashboardView');
@@ -269,7 +268,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       if (user) {
         const updated = { ...user, active: true, requiresPasswordSetup: false };
         setUser(updated);
-        localStorage.setItem('user', JSON.stringify(updated));
       }
     } catch (error) {
       console.error('Erro ao definir password:', error);


### PR DESCRIPTION
- User object (id, email, nome, role, nif, telefone) no longer stored in localStorage
- Only non-sensitive lastActivity timestamp is kept for inactivity detection
- User state is always reconstructed from server via GET /api/auth/me on page load
- Prevents XSS attacks from stealing user profile data

## Summary by Sourcery

Remove caching of user profile data in localStorage and retain only a non-sensitive last-activity timestamp for auth state handling and inactivity detection.

Bug Fixes:
- Eliminate storage of sensitive user profile information in localStorage to reduce exposure to XSS-based data theft.

Enhancements:
- Ensure user state is reconstructed from the server instead of relying on locally cached user data in localStorage.