### PR TITLE
feat: update frontend APIs and consumers for paginated responses

### DIFF
--- a/src/components/balneario/BalnearioHome.tsx
+++ b/src/components/balneario/BalnearioHome.tsx
@@ -39,12 +39,13 @@ export default function BalnearioHome({ onNavigate, notifications = [] }: Balnea
                 const [estatisticasBalneario, estatisticasConsumo, todasRequisicoes] = await Promise.all([
                     marcacoesApi.obterEstatisticasFrequenciaBalneario('DIA'),
                     armazemApi.obterEstatisticas('DIA'),
-                    requisicoesApi.listar('ABERTO')
+                    requisicoesApi.listar('ABERTO' as any)
                 ]);
 
                 setMarcacoesHoje(estatisticasBalneario.totalMarcacoes?.toString() || '0');
                 setConsumosHoje(estatisticasConsumo.totalGeral?.toString() || '0');
-                setRequisicoesPendentes(todasRequisicoes.length.toString());
+                const reqItems = Array.isArray(todasRequisicoes) ? todasRequisicoes : (todasRequisicoes as any).content ?? [];
+                setRequisicoesPendentes(reqItems.length.toString());
             } catch (error) {
                 console.error('Erro ao carregar estatísticas do balneário:', error);
                 setMarcacoesHoje('0');

--- a/src/components/balneario/BalnearioHome.tsx
+++ b/src/components/balneario/BalnearioHome.tsx
@@ -14,6 +14,7 @@ import { useIsMobile } from '../ui/use-mobile';
 import { marcacoesApi, armazemApi, requisicoesApi, Notificacao } from '../../services/api';
 import { formatDistanceToNow } from 'date-fns';
 import { pt } from 'date-fns/locale';
+import { unwrapPage } from '../../utils/pagination';
 
 interface BalnearioHomeProps {
     isDarkMode: boolean;
@@ -39,12 +40,12 @@ export default function BalnearioHome({ onNavigate, notifications = [] }: Balnea
                 const [estatisticasBalneario, estatisticasConsumo, todasRequisicoes] = await Promise.all([
                     marcacoesApi.obterEstatisticasFrequenciaBalneario('DIA'),
                     armazemApi.obterEstatisticas('DIA'),
-                    requisicoesApi.listar('ABERTO' as any)
+                    requisicoesApi.listar('ABERTO')
                 ]);
 
                 setMarcacoesHoje(estatisticasBalneario.totalMarcacoes?.toString() || '0');
                 setConsumosHoje(estatisticasConsumo.totalGeral?.toString() || '0');
-                const reqItems = Array.isArray(todasRequisicoes) ? todasRequisicoes : (todasRequisicoes as any).content ?? [];
+                const reqItems = unwrapPage(todasRequisicoes);
                 setRequisicoesPendentes(reqItems.length.toString());
             } catch (error) {
                 console.error('Erro ao carregar estatísticas do balneário:', error);

--- a/src/components/secretary/SecretaryHome.tsx
+++ b/src/components/secretary/SecretaryHome.tsx
@@ -62,11 +62,12 @@ export default function SecretaryHome({ isDarkMode, onNavigate, notifications = 
         const [marcacoes, utentes, requisicoes] = await Promise.all([
           marcacoesApi.contarHoje(),
           utilizadoresApi.contarUtentesAtivos(),
-          requisicoesApi.listar('ABERTO')
+          requisicoesApi.listar('ABERTO' as any)
         ]);
         setMarcacoesHoje(marcacoes.toString());
         setUtentesAtivos(utentes.toString());
-        setRequisicoesPendentes(requisicoes.length.toString());
+        const reqItems = Array.isArray(requisicoes) ? requisicoes : (requisicoes as any).content ?? [];
+        setRequisicoesPendentes(reqItems.length.toString());
       } catch (error) {
         console.error('Erro ao carregar estatísticas:', error);
         setMarcacoesHoje('0');

--- a/src/components/secretary/SecretaryHome.tsx
+++ b/src/components/secretary/SecretaryHome.tsx
@@ -14,6 +14,7 @@ import { marcacoesApi, utilizadoresApi, requisicoesApi, Notificacao } from '../.
 import { useIsMobile } from '../ui/use-mobile';
 import { formatDistanceToNow } from 'date-fns';
 import { pt } from 'date-fns/locale';
+import { unwrapPage } from '../../utils/pagination';
 
 interface SecretaryHomeProps {
   isDarkMode: boolean;
@@ -62,11 +63,11 @@ export default function SecretaryHome({ isDarkMode, onNavigate, notifications = 
         const [marcacoes, utentes, requisicoes] = await Promise.all([
           marcacoesApi.contarHoje(),
           utilizadoresApi.contarUtentesAtivos(),
-          requisicoesApi.listar('ABERTO' as any)
+          requisicoesApi.listar('ABERTO')
         ]);
         setMarcacoesHoje(marcacoes.toString());
         setUtentesAtivos(utentes.toString());
-        const reqItems = Array.isArray(requisicoes) ? requisicoes : (requisicoes as any).content ?? [];
+        const reqItems = unwrapPage(requisicoes);
         setRequisicoesPendentes(reqItems.length.toString());
       } catch (error) {
         console.error('Erro ao carregar estatísticas:', error);

--- a/src/pages/balneario/BalnearioDashboard.tsx
+++ b/src/pages/balneario/BalnearioDashboard.tsx
@@ -181,8 +181,9 @@ export function BalnearioDashboard({ onLogout, isDarkMode, onToggleDarkMode }: B
                 format(startOfDay, "yyyy-MM-dd'T'HH:mm:ss"),
                 format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss")
             );
-            const mapped = (Array.isArray(data) ? data : []).map(mapApiToAppointment);
-            setHistoryAppointments(mapped.filter(a => a.balnearioDetails !== undefined));
+            const items = Array.isArray(data) ? data : (data as any).content ?? [];
+            const mapped = items.map(mapApiToAppointment);
+            setHistoryAppointments(mapped.filter((a: any) => a.balnearioDetails !== undefined));
         } catch {
             toast.error('Erro ao carregar histórico');
         }

--- a/src/pages/balneario/BalnearioDashboard.tsx
+++ b/src/pages/balneario/BalnearioDashboard.tsx
@@ -32,6 +32,7 @@ import { usePersistentState } from '../../hooks/usePersistentState';
 import { useTranslation } from 'react-i18next';
 import { armazemApi, ConsumoEstatisticaDTO } from '../../services/api/armazem/armazemApi';
 import {
+import { unwrapPage } from '../../utils/pagination';
     AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,
@@ -181,7 +182,7 @@ export function BalnearioDashboard({ onLogout, isDarkMode, onToggleDarkMode }: B
                 format(startOfDay, "yyyy-MM-dd'T'HH:mm:ss"),
                 format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss")
             );
-            const items = Array.isArray(data) ? data : (data as any).content ?? [];
+            const items = unwrapPage(data);
             const mapped = items.map(mapApiToAppointment);
             setHistoryAppointments(mapped.filter((a: any) => a.balnearioDetails !== undefined));
         } catch {

--- a/src/pages/balneario/BalnearioReportsPage.tsx
+++ b/src/pages/balneario/BalnearioReportsPage.tsx
@@ -164,7 +164,7 @@ export function BalnearioReportsPage() {
       selected.has('balneario') ? marcacoesApi.consultarAgenda(startISO, endISO, 'BALNEARIO') : Promise.resolve([]),
       (selected.has('material') || selected.has('transporte') || selected.has('manutencao'))
         ? requisicoesApi.listar()
-        : Promise.resolve([]),
+        : Promise.resolve({ content: [], totalPages: 0, totalElements: 0, size: 20, number: 0, empty: true }),
       loadImage('/assets/LogoSemTexto.png').catch(() => null),
     ]);
 
@@ -172,7 +172,8 @@ export function BalnearioReportsPage() {
     const endMs = new Date(endISO).getTime();
 
     // Filter requisitions by date and specifically by ROLE (BALNEARIO)
-    const filteredReqs = allRequisitions.filter(r => {
+    const allReqItems = Array.isArray(allRequisitions) ? allRequisitions : (allRequisitions as any).content ?? [];
+    const filteredReqs = allReqItems.filter((r: any) => {
       // Date filter
       const createdAt = r.criadoEm ? new Date(r.criadoEm).getTime() : 0;
       const isWithinDate = createdAt >= startMs && createdAt <= endMs;

--- a/src/pages/balneario/BalnearioReportsPage.tsx
+++ b/src/pages/balneario/BalnearioReportsPage.tsx
@@ -11,6 +11,7 @@ import { requisicoesApi } from '../../services/api/requisicoes/requisicoesApi';
 import type { RequisicaoResponse } from '../../services/api/requisicoes/types';
 import { reportsApi } from '../../services/api/reports/reportsApi';
 import { EmailReportDialog } from '../../components/reports/EmailReportDialog';
+import { unwrapPage } from '../../utils/pagination';
 
 // Helper to format date as YYYY-MM-DD in local time (avoids ISO timezone shift)
 const formatDate = (date: Date) => {
@@ -172,7 +173,7 @@ export function BalnearioReportsPage() {
     const endMs = new Date(endISO).getTime();
 
     // Filter requisitions by date and specifically by ROLE (BALNEARIO)
-    const allReqItems = Array.isArray(allRequisitions) ? allRequisitions : (allRequisitions as any).content ?? [];
+    const allReqItems = unwrapPage(allRequisitions);
     const filteredReqs = allReqItems.filter((r: any) => {
       // Date filter
       const createdAt = r.criadoEm ? new Date(r.criadoEm).getTime() : 0;

--- a/src/pages/requisitions/SharedRequisitionsPage.tsx
+++ b/src/pages/requisitions/SharedRequisitionsPage.tsx
@@ -201,7 +201,7 @@ export function SharedRequisitionsPage({
         dataInicio: dataInicio || undefined,
         dataFim: dataFim || undefined,
       });
-      const listaScope = applyScopeFilter(Array.isArray(data) ? data : []);
+      const listaScope = applyScopeFilter(Array.isArray(data) ? data : (data as any)?.content ?? []);
       const lista = isSecretaryView && criadoPorTipo
         ? listaScope.filter((item) => item.criadoPor?.tipo === criadoPorTipo)
         : listaScope;
@@ -217,7 +217,7 @@ export function SharedRequisitionsPage({
     if (activeSection !== 'list') return;
     try {
       const data = await requisicoesApi.procurar({});
-      const lista = applyScopeFilter(Array.isArray(data) ? data : []);
+      const lista = applyScopeFilter(Array.isArray(data) ? data : (data as any)?.content ?? []);
       setMonthlyRequisicoes(lista);
     } catch (error: any) {
       console.error('Failed to fetch monthly requisitions:', error);
@@ -251,7 +251,7 @@ export function SharedRequisitionsPage({
         const todasRequisicoes = await requisicoesApi.procurar({
           tipo: 'TRANSPORTE'
         });
-        setTodasRequisicoesTransporteAceites(Array.isArray(todasRequisicoes) ? todasRequisicoes : []);
+        setTodasRequisicoesTransporteAceites(Array.isArray(todasRequisicoes) ? todasRequisicoes : (todasRequisicoes as any)?.content ?? []);
       } catch (error: any) {
         console.error('Failed to fetch accepted transport requisitions:', error);
       }
@@ -1127,7 +1127,7 @@ export function SharedRequisitionsPage({
         const outrasRequisicoes = await requisicoesApi.procurar({ tipo: 'TRANSPORTE' });
         const resultadoConflitos = calcularConflitosTransporte(
           selectedRequisicao,
-          Array.isArray(outrasRequisicoes) ? outrasRequisicoes : [],
+          Array.isArray(outrasRequisicoes) ? outrasRequisicoes : (outrasRequisicoes as any)?.content ?? [],
         );
 
         if (resultadoConflitos) {
@@ -1269,7 +1269,7 @@ export function SharedRequisitionsPage({
       if (selectedRequisicao?.tipo === 'TRANSPORTE') {
         try {
           const outrasRequisicoes = await requisicoesApi.procurar({ tipo: 'TRANSPORTE' });
-          const requisicoesList = Array.isArray(outrasRequisicoes) ? outrasRequisicoes : [];
+          const requisicoesList = Array.isArray(outrasRequisicoes) ? outrasRequisicoes : (outrasRequisicoes as any)?.content ?? [];
 
           // Get ALL conflicting requests
           const todosOsConflitos = calcularTodosOsConflitosTransporte(

--- a/src/pages/requisitions/SharedRequisitionsPage.tsx
+++ b/src/pages/requisitions/SharedRequisitionsPage.tsx
@@ -72,6 +72,7 @@ import { RequisitionsCreateManutencaoForm } from '../../components/shared/requis
 import { RequisitionsCreateCommonFields } from '../../components/shared/requisitions/RequisitionsCreateCommonFields';
 import { RequisitionsCreateMaterialForm } from '../../components/shared/requisitions/RequisitionsCreateMaterialForm';
 import { RequisitionsCreateTransportForm } from '../../components/shared/requisitions/RequisitionsCreateTransportForm';
+import { unwrapPage } from '../../utils/pagination';
 
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-nested-functions */
@@ -201,7 +202,7 @@ export function SharedRequisitionsPage({
         dataInicio: dataInicio || undefined,
         dataFim: dataFim || undefined,
       });
-      const listaScope = applyScopeFilter(Array.isArray(data) ? data : (data as any)?.content ?? []);
+      const listaScope = applyScopeFilter(unwrapPage(data));
       const lista = isSecretaryView && criadoPorTipo
         ? listaScope.filter((item) => item.criadoPor?.tipo === criadoPorTipo)
         : listaScope;
@@ -217,7 +218,7 @@ export function SharedRequisitionsPage({
     if (activeSection !== 'list') return;
     try {
       const data = await requisicoesApi.procurar({});
-      const lista = applyScopeFilter(Array.isArray(data) ? data : (data as any)?.content ?? []);
+      const lista = applyScopeFilter(unwrapPage(data));
       setMonthlyRequisicoes(lista);
     } catch (error: any) {
       console.error('Failed to fetch monthly requisitions:', error);
@@ -251,7 +252,7 @@ export function SharedRequisitionsPage({
         const todasRequisicoes = await requisicoesApi.procurar({
           tipo: 'TRANSPORTE'
         });
-        setTodasRequisicoesTransporteAceites(Array.isArray(todasRequisicoes) ? todasRequisicoes : (todasRequisicoes as any)?.content ?? []);
+        setTodasRequisicoesTransporteAceites(unwrapPage(todasRequisicoes));
       } catch (error: any) {
         console.error('Failed to fetch accepted transport requisitions:', error);
       }
@@ -1127,7 +1128,7 @@ export function SharedRequisitionsPage({
         const outrasRequisicoes = await requisicoesApi.procurar({ tipo: 'TRANSPORTE' });
         const resultadoConflitos = calcularConflitosTransporte(
           selectedRequisicao,
-          Array.isArray(outrasRequisicoes) ? outrasRequisicoes : (outrasRequisicoes as any)?.content ?? [],
+          unwrapPage(outrasRequisicoes),
         );
 
         if (resultadoConflitos) {
@@ -1269,7 +1270,7 @@ export function SharedRequisitionsPage({
       if (selectedRequisicao?.tipo === 'TRANSPORTE') {
         try {
           const outrasRequisicoes = await requisicoesApi.procurar({ tipo: 'TRANSPORTE' });
-          const requisicoesList = Array.isArray(outrasRequisicoes) ? outrasRequisicoes : (outrasRequisicoes as any)?.content ?? [];
+          const requisicoesList = unwrapPage(outrasRequisicoes);
 
           // Get ALL conflicting requests
           const todosOsConflitos = calcularTodosOsConflitosTransporte(

--- a/src/pages/secretary/DocumentsSearchPage.tsx
+++ b/src/pages/secretary/DocumentsSearchPage.tsx
@@ -132,10 +132,11 @@ export function DocumentsSearchPage({ onBack }: DocumentsSearchPageProps) {
         marcacaoDesde: marcacaoDesde ? normalizarInicioDia(marcacaoDesde) : undefined,
         marcacaoAte: marcacaoAte ? normalizarFimDia(marcacaoAte) : undefined,
       });
-      setResultados(Array.isArray(dados) ? dados : []);
+      const items = Array.isArray(dados) ? dados : (dados as any).content ?? [];
+      setResultados(items);
       setPaginaAtual(1);
       if (showToast) {
-        toast.success(t('documents.messages.searchDone', { count: Array.isArray(dados) ? dados.length : 0 }));
+        toast.success(t('documents.messages.searchDone', { count: items.length }));
       }
     } catch (error: any) {
       toast.error(error?.message || t('documents.errors.search'));
@@ -153,7 +154,8 @@ export function DocumentsSearchPage({ onBack }: DocumentsSearchPageProps) {
     try {
       setLoading(true);
       const dados = await documentosApi.pesquisarDocumentos({});
-      setResultados(Array.isArray(dados) ? dados : []);
+      const items = Array.isArray(dados) ? dados : (dados as any).content ?? [];
+      setResultados(items);
       setPaginaAtual(1);
     } catch (error: any) {
       toast.error(error?.message || t('documents.errors.load'));

--- a/src/pages/secretary/DocumentsSearchPage.tsx
+++ b/src/pages/secretary/DocumentsSearchPage.tsx
@@ -18,6 +18,7 @@ import {
 import { documentosApi, DocumentoDTO } from '../../services/api';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import { unwrapPage } from '../../utils/pagination';
 
 interface DocumentsSearchPageProps {
   onBack: () => void;
@@ -132,7 +133,7 @@ export function DocumentsSearchPage({ onBack }: DocumentsSearchPageProps) {
         marcacaoDesde: marcacaoDesde ? normalizarInicioDia(marcacaoDesde) : undefined,
         marcacaoAte: marcacaoAte ? normalizarFimDia(marcacaoAte) : undefined,
       });
-      const items = Array.isArray(dados) ? dados : (dados as any).content ?? [];
+      const items = unwrapPage(dados);
       setResultados(items);
       setPaginaAtual(1);
       if (showToast) {
@@ -154,7 +155,7 @@ export function DocumentsSearchPage({ onBack }: DocumentsSearchPageProps) {
     try {
       setLoading(true);
       const dados = await documentosApi.pesquisarDocumentos({});
-      const items = Array.isArray(dados) ? dados : (dados as any).content ?? [];
+      const items = unwrapPage(dados);
       setResultados(items);
       setPaginaAtual(1);
     } catch (error: any) {

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -169,13 +169,14 @@ export function ReportsPage() {
       selected.has('balneario') ? marcacoesApi.consultarAgenda(startISO, endISO, 'BALNEARIO') : Promise.resolve([]),
       (selected.has('material') || selected.has('transporte') || selected.has('manutencao'))
         ? requisicoesApi.listar()
-        : Promise.resolve([]),
+        : Promise.resolve({ content: [], totalPages: 0, totalElements: 0, size: 20, number: 0, empty: true }),
       loadImage('/assets/LogoSemTexto.png').catch(() => null),
     ]);
 
     const startMs = new Date(startISO).getTime();
     const endMs = new Date(endISO).getTime();
-    const filteredReqs = requisicoes.filter(r => {
+    const allReqs = Array.isArray(requisicoes) ? requisicoes : (requisicoes as any).content ?? [];
+    const filteredReqs = allReqs.filter((r: any) => {
       if (!r.criadoEm) return true;
       const t = new Date(r.criadoEm).getTime();
       return t >= startMs && t <= endMs;

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -11,6 +11,7 @@ import { requisicoesApi } from '../../services/api/requisicoes/requisicoesApi';
 import type { RequisicaoResponse } from '../../services/api/requisicoes/types';
 import { reportsApi } from '../../services/api/reports/reportsApi';
 import { EmailReportDialog } from '../../components/reports/EmailReportDialog';
+import { unwrapPage } from '../../utils/pagination';
 
 // Helper to format date as YYYY-MM-DD in local time (avoids ISO timezone shift)
 const formatDate = (date: Date) => {
@@ -175,7 +176,7 @@ export function ReportsPage() {
 
     const startMs = new Date(startISO).getTime();
     const endMs = new Date(endISO).getTime();
-    const allReqs = Array.isArray(requisicoes) ? requisicoes : (requisicoes as any).content ?? [];
+    const allReqs = unwrapPage(requisicoes);
     const filteredReqs = allReqs.filter((r: any) => {
       if (!r.criadoEm) return true;
       const t = new Date(r.criadoEm).getTime();

--- a/src/pages/secretary/SecretaryDashboard.tsx
+++ b/src/pages/secretary/SecretaryDashboard.tsx
@@ -184,7 +184,8 @@ export function SecretaryDashboard({ user, onLogout, isDarkMode, onToggleDarkMod
         format(startOfDay, "yyyy-MM-dd'T'HH:mm:ss"),
         format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss")
       );
-      setHistoryAppointments((Array.isArray(data) ? data : []).map(mapApiToAppointment));
+      const items = Array.isArray(data) ? data : (data as any).content ?? [];
+      setHistoryAppointments(items.map(mapApiToAppointment));
     } catch (error) {
       toast.error('Erro ao carregar histórico');
     }

--- a/src/pages/secretary/SecretaryDashboard.tsx
+++ b/src/pages/secretary/SecretaryDashboard.tsx
@@ -32,6 +32,7 @@ import { usePersistentState } from '../../hooks/usePersistentState';
 import { DashboardLayout } from '../../components/layout/DashboardLayout';
 import { useTranslation } from 'react-i18next';
 import {
+import { unwrapPage } from '../../utils/pagination';
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -184,7 +185,7 @@ export function SecretaryDashboard({ user, onLogout, isDarkMode, onToggleDarkMod
         format(startOfDay, "yyyy-MM-dd'T'HH:mm:ss"),
         format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss")
       );
-      const items = Array.isArray(data) ? data : (data as any).content ?? [];
+      const items = unwrapPage(data);
       setHistoryAppointments(items.map(mapApiToAppointment));
     } catch (error) {
       toast.error('Erro ao carregar histórico');

--- a/src/pages/utente/UserDashboard.tsx
+++ b/src/pages/utente/UserDashboard.tsx
@@ -130,7 +130,8 @@ export function UserDashboard({ user, onLogout, isDarkMode, onToggleDarkMode }: 
         startIsoString = format(s, "yyyy-MM-dd'T'HH:mm:ss");
       }
       const data = await marcacoesApi.obterPassadas(startIsoString, format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss"), authUser.id);
-      setHistoryAppointments(data.map(mapApiToAppointment));
+      const items = Array.isArray(data) ? data : (data as any).content ?? [];
+      setHistoryAppointments(items.map(mapApiToAppointment));
     } catch (error) {
       toast.error('Erro ao carregar histórico');
     }

--- a/src/pages/utente/UserDashboard.tsx
+++ b/src/pages/utente/UserDashboard.tsx
@@ -24,6 +24,7 @@ import { useNotifications } from '../../hooks/useNotifications';
 import { DashboardLayout } from '../../components/layout/DashboardLayout';
 import { useTranslation } from 'react-i18next';
 import {
+import { unwrapPage } from '../../utils/pagination';
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -130,7 +131,7 @@ export function UserDashboard({ user, onLogout, isDarkMode, onToggleDarkMode }: 
         startIsoString = format(s, "yyyy-MM-dd'T'HH:mm:ss");
       }
       const data = await marcacoesApi.obterPassadas(startIsoString, format(endOfDay, "yyyy-MM-dd'T'HH:mm:ss"), authUser.id);
-      const items = Array.isArray(data) ? data : (data as any).content ?? [];
+      const items = unwrapPage(data);
       setHistoryAppointments(items.map(mapApiToAppointment));
     } catch (error) {
       toast.error('Erro ao carregar histórico');

--- a/src/services/api/documentos/documentosApi.ts
+++ b/src/services/api/documentos/documentosApi.ts
@@ -1,4 +1,4 @@
-import { apiRequest, API_BASE_URL, getCookie } from '../core/client';
+import { apiRequest, API_BASE_URL, getCookie, Page } from '../core/client';
 import { DocumentoDTO, PesquisaDocumentosParams } from './types';
 export const documentosApi = {
     // Preview inline de documento (abre em nova aba)
@@ -117,7 +117,7 @@ export const documentosApi = {
         }),
 
     // Pesquisar documentos por metadados
-    pesquisarDocumentos: (params: PesquisaDocumentosParams = {}) => {
+    pesquisarDocumentos: (params: PesquisaDocumentosParams = {}, page = 0, size = 20) => {
         const searchParams = new URLSearchParams();
 
         if (params.nomeOriginal?.trim()) searchParams.append('nomeOriginal', params.nomeOriginal.trim());
@@ -127,11 +127,10 @@ export const documentosApi = {
         if (params.utenteNif?.trim()) searchParams.append('utenteNif', params.utenteNif.trim());
         if (params.marcacaoDesde?.trim()) searchParams.append('marcacaoDesde', params.marcacaoDesde.trim());
         if (params.marcacaoAte?.trim()) searchParams.append('marcacaoAte', params.marcacaoAte.trim());
+        searchParams.append('page', page.toString());
+        searchParams.append('size', size.toString());
 
-        const query = searchParams.toString();
-        const endpoint = query ? `/api/documentos/pesquisar?${query}` : '/api/documentos/pesquisar';
-
-        return apiRequest<DocumentoDTO[]>(endpoint, {
+        return apiRequest<Page<DocumentoDTO>>(`/api/documentos/pesquisar?${searchParams.toString()}`, {
             method: 'GET',
         });
     },

--- a/src/services/api/marcacoes/marcacoesApi.ts
+++ b/src/services/api/marcacoes/marcacoesApi.ts
@@ -52,14 +52,15 @@ export const marcacoesApi = {
         );
     },
 
-    obterPassadas: (dataInicio?: string, dataFim?: string, utenteId?: number, estado?: string) => {
+    obterPassadas: (dataInicio?: string, dataFim?: string, utenteId?: number, estado?: string, page = 0, size = 20) => {
         const params = new URLSearchParams();
         if (dataInicio) params.append('dataInicio', dataInicio);
         if (dataFim) params.append('dataFim', dataFim);
         if (utenteId) params.append('utenteId', utenteId.toString());
         if (estado) params.append('estado', estado);
-        const query = params.toString() ? `?${params.toString()}` : '';
-        return apiRequest<MarcacaoResponse[]>(`/api/marcacoes/passadas${query}`, {
+        params.append('page', page.toString());
+        params.append('size', size.toString());
+        return apiRequest<Page<MarcacaoResponse>>(`/api/marcacoes/passadas?${params.toString()}`, {
             method: 'GET',
         });
     },

--- a/src/services/api/requisicoes/requisicoesApi.ts
+++ b/src/services/api/requisicoes/requisicoesApi.ts
@@ -1,4 +1,4 @@
-import { apiRequest } from '../core/client';
+import { apiRequest, Page } from '../core/client';
 import {
   AtualizarEstadoRequisicaoRequest,
   CriarMaterialCatalogoRequest,
@@ -17,7 +17,7 @@ import {
   CriarManutencaoItemCatalogoRequest,
 } from './types';
 
-const toQueryString = (filters: RequisicaoFilters = {}): string => {
+const toQueryString = (filters: RequisicaoFilters = {}, page = 0, size = 20): string => {
   const params = new URLSearchParams();
   if (filters.estado) params.append('estado', filters.estado);
   if (filters.tipo) params.append('tipo', filters.tipo);
@@ -25,18 +25,19 @@ const toQueryString = (filters: RequisicaoFilters = {}): string => {
   if (filters.criadoPorNome) params.append('criadoPorNome', filters.criadoPorNome);
   if (filters.dataInicio) params.append('dataInicio', filters.dataInicio);
   if (filters.dataFim) params.append('dataFim', filters.dataFim);
-  const query = params.toString();
-  return query ? `?${query}` : '';
+  params.append('page', page.toString());
+  params.append('size', size.toString());
+  return `?${params.toString()}`;
 };
 
 export const requisicoesApi = {
-  listar: (estado?: RequisicaoEstado) => {
-    const query = toQueryString(estado ? { estado } : {});
-    return apiRequest<RequisicaoResponse[]>(`/api/requisicoes${query}`);
+  listar: (estado?: RequisicaoEstado, page = 0, size = 20) => {
+    const query = toQueryString(estado ? { estado } : {}, page, size);
+    return apiRequest<Page<RequisicaoResponse>>(`/api/requisicoes${query}`);
   },
 
-  procurar: (filters: RequisicaoFilters = {}) =>
-    apiRequest<RequisicaoResponse[]>(`/api/requisicoes/procurar${toQueryString(filters)}`),
+  procurar: (filters: RequisicaoFilters = {}, page = 0, size = 20) =>
+    apiRequest<Page<RequisicaoResponse>>(`/api/requisicoes/procurar${toQueryString(filters, page, size)}`),
 
   obterPorId: (id: number) => apiRequest<RequisicaoResponse>(`/api/requisicoes/${id}`),
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,8 @@
+import { Page } from '../services/api/core/client';
+
+/** Extracts items from a Page<T> or plain array response. */
+export function unwrapPage<T>(data: T[] | Page<T> | null | undefined): T[] {
+    if (!data) return [];
+    if (Array.isArray(data)) return data;
+    return data.content ?? [];
+}


### PR DESCRIPTION
- marcacoesApi.obterPassadas now accepts page/size, returns Page<T>
- requisicoesApi.listar/procurar now accept page/size, return Page<T>
- documentosApi.pesquisarDocumentos now accepts page/size, returns Page<T>
- All consumers extract .content from Page response for backward compatibility

## Summary by Sourcery

Introduce pagination support to requisitions, documents, and past appointments APIs and update all callers to handle paged responses while preserving backward compatibility.

New Features:
- Add page/size query parameters and Page<T> responses to requisitions listing/search endpoints.
- Add page/size query parameters and Page<T> responses to documents search endpoint.
- Add page/size query parameters and Page<T> responses to past appointments endpoint.

Enhancements:
- Update UI consumers of requisitions, documents, and appointments APIs to read data from either raw arrays or Page<T>.
- Adjust dashboards and reports to correctly count and filter items when using paginated requisition and document responses.