### PR TITLE
feat: filtering de utilizadores no servidor (F1 frontend)

### DIFF
--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useMemo, type ReactNode } from 'react';
+import { useState, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { utilizadoresApi } from '../../services/api';
 import { maskNif } from '../../utils/maskNif';
+import { useDebounce } from '../../hooks/useDebounce';
+import { PAGINATION } from '../../config/pagination';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -168,52 +170,50 @@ export function UserManagement() {
         }
     };
 
-    useEffect(() => {
-        setCurrentPage(1);
-        const t = setTimeout(() => fetchUsers(searchQuery), 300);
-        return () => clearTimeout(t);
-    }, [searchQuery]);
-
-    useEffect(() => {
-        setCurrentPageUtentes(1);
-        const t = setTimeout(() => fetchUtentes(searchQueryUtentes), 300);
-        return () => clearTimeout(t);
-    }, [searchQueryUtentes]);
+    useDebounce(() => { setCurrentPage(1); fetchUsers(searchQuery); }, [searchQuery]);
+    useDebounce(() => { setCurrentPageUtentes(1); fetchUtentes(searchQueryUtentes); }, [searchQueryUtentes]);
 
     useEffect(() => {
         fetchUsers();
         fetchUtentes();
     }, []);
 
+    const abortUsersRef = useRef<AbortController | null>(null);
+    const abortUtentesRef = useRef<AbortController | null>(null);
+
     const fetchUsers = async (nome?: string) => {
+        abortUsersRef.current?.abort();
+        abortUsersRef.current = new AbortController();
         setIsLoading(true);
         try {
-            const data = await utilizadoresApi.listarFuncionarios(nome || undefined, undefined, 0, 200);
+            const data = await utilizadoresApi.listarFuncionarios(nome || undefined, undefined, PAGINATION.DEFAULT_PAGE, PAGINATION.USERS_PAGE_SIZE);
             const list = Array.isArray(data) ? data : data.content ?? [];
             const sorted = [...list].sort((a, b) => {
                 if (a.active !== b.active) return a.active ? 1 : -1;
                 return (b.id || 0) - (a.id || 0);
             });
             setUsers(sorted);
-        } catch (error) {
-            console.error("Failed to fetch users", error);
+        } catch (error: any) {
+            if (error?.name !== 'AbortError') console.error("Failed to fetch users", error);
         } finally {
             setIsLoading(false);
         }
     };
 
     const fetchUtentes = async (nome?: string) => {
+        abortUtentesRef.current?.abort();
+        abortUtentesRef.current = new AbortController();
         setIsLoadingUtentes(true);
         try {
-            const data = await utilizadoresApi.listarUtentes(nome || undefined, 0, 200);
+            const data = await utilizadoresApi.listarUtentes(nome || undefined, PAGINATION.DEFAULT_PAGE, PAGINATION.USERS_PAGE_SIZE);
             const list = Array.isArray(data) ? data : data.content ?? [];
             const sorted = [...list].sort((a, b) => {
                 if (a.active !== b.active) return a.active ? 1 : -1;
                 return (b.id || 0) - (a.id || 0);
             });
             setUtentes(sorted);
-        } catch (error) {
-            console.error("Failed to fetch utentes", error);
+        } catch (error: any) {
+            if (error?.name !== 'AbortError') console.error("Failed to fetch utentes", error);
         } finally {
             setIsLoadingUtentes(false);
         }

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -170,18 +170,27 @@ export function UserManagement() {
 
     useEffect(() => {
         setCurrentPage(1);
+        const t = setTimeout(() => fetchUsers(searchQuery), 300);
+        return () => clearTimeout(t);
     }, [searchQuery]);
+
+    useEffect(() => {
+        setCurrentPageUtentes(1);
+        const t = setTimeout(() => fetchUtentes(searchQueryUtentes), 300);
+        return () => clearTimeout(t);
+    }, [searchQueryUtentes]);
 
     useEffect(() => {
         fetchUsers();
         fetchUtentes();
     }, []);
 
-    const fetchUsers = async () => {
+    const fetchUsers = async (nome?: string) => {
         setIsLoading(true);
         try {
-            const data = await utilizadoresApi.listarFuncionarios();
-            const sorted = [...data].sort((a, b) => {
+            const data = await utilizadoresApi.listarFuncionarios(nome || undefined, undefined, 0, 200);
+            const list = Array.isArray(data) ? data : data.content ?? [];
+            const sorted = [...list].sort((a, b) => {
                 if (a.active !== b.active) return a.active ? 1 : -1;
                 return (b.id || 0) - (a.id || 0);
             });
@@ -193,11 +202,12 @@ export function UserManagement() {
         }
     };
 
-    const fetchUtentes = async () => {
+    const fetchUtentes = async (nome?: string) => {
         setIsLoadingUtentes(true);
         try {
-            const data = await utilizadoresApi.listarUtentes();
-            const sorted = [...data].sort((a, b) => {
+            const data = await utilizadoresApi.listarUtentes(nome || undefined, 0, 200);
+            const list = Array.isArray(data) ? data : data.content ?? [];
+            const sorted = [...list].sort((a, b) => {
                 if (a.active !== b.active) return a.active ? 1 : -1;
                 return (b.id || 0) - (a.id || 0);
             });
@@ -553,17 +563,9 @@ export function UserManagement() {
         }
     };
 
-    // Filter users (Employees)
-    const filteredUsers = users.filter(user =>
-        user.nome.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        user.nif.includes(searchQuery)
-    );
-
-    // Filter utentes
-    const filteredUtentesList = utentes.filter(u =>
-        u.nome.toLowerCase().includes(searchQueryUtentes.toLowerCase()) ||
-        u.nif.includes(searchQueryUtentes)
-    );
+    // Server-side filtering: users/utentes already filtered by searchQuery
+    const filteredUsers = users;
+    const filteredUtentesList = utentes;
 
     const pendingCount = users.filter(u => u.active === false).length;
 

--- a/src/config/pagination.ts
+++ b/src/config/pagination.ts
@@ -1,0 +1,5 @@
+export const PAGINATION = {
+    DEFAULT_PAGE: 0,
+    /** Page size for user lists (funcionários/utentes) */
+    USERS_PAGE_SIZE: 200,
+} as const;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react';
+
+export function useDebounce(fn: () => void, deps: unknown[], delay = 300): void {
+    const fnRef = useRef(fn);
+    fnRef.current = fn;
+
+    useEffect(() => {
+        const t = setTimeout(() => fnRef.current(), delay);
+        return () => clearTimeout(t);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [...deps, delay]);
+}

--- a/src/pages/balneario/BalnearioDashboard.tsx
+++ b/src/pages/balneario/BalnearioDashboard.tsx
@@ -31,8 +31,8 @@ import { useSlidingWindowAppointments } from '../../hooks/useSlidingWindowAppoin
 import { usePersistentState } from '../../hooks/usePersistentState';
 import { useTranslation } from 'react-i18next';
 import { armazemApi, ConsumoEstatisticaDTO } from '../../services/api/armazem/armazemApi';
-import {
 import { unwrapPage } from '../../utils/pagination';
+import {
     AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,

--- a/src/pages/secretary/SecretaryDashboard.tsx
+++ b/src/pages/secretary/SecretaryDashboard.tsx
@@ -31,8 +31,8 @@ import { useSlidingWindowAppointments } from '../../hooks/useSlidingWindowAppoin
 import { usePersistentState } from '../../hooks/usePersistentState';
 import { DashboardLayout } from '../../components/layout/DashboardLayout';
 import { useTranslation } from 'react-i18next';
-import {
 import { unwrapPage } from '../../utils/pagination';
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,

--- a/src/pages/utente/UserDashboard.tsx
+++ b/src/pages/utente/UserDashboard.tsx
@@ -23,8 +23,8 @@ import { useAppointments } from '../../hooks/useAppointments';
 import { useNotifications } from '../../hooks/useNotifications';
 import { DashboardLayout } from '../../components/layout/DashboardLayout';
 import { useTranslation } from 'react-i18next';
-import {
 import { unwrapPage } from '../../utils/pagination';
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,

--- a/src/services/api/marcacoes/marcacoesApi.ts
+++ b/src/services/api/marcacoes/marcacoesApi.ts
@@ -52,12 +52,14 @@ export const marcacoesApi = {
         );
     },
 
-    obterPassadas: (dataInicio?: string, dataFim?: string, utenteId?: number, estado?: string, page = 0, size = 20) => {
+    obterPassadas: (dataInicio?: string, dataFim?: string, utenteId?: number, estado?: string, page = 0, size = 20, assunto?: string, nomeUtente?: string) => {
         const params = new URLSearchParams();
         if (dataInicio) params.append('dataInicio', dataInicio);
         if (dataFim) params.append('dataFim', dataFim);
         if (utenteId) params.append('utenteId', utenteId.toString());
         if (estado) params.append('estado', estado);
+        if (assunto) params.append('assunto', assunto);
+        if (nomeUtente) params.append('nomeUtente', nomeUtente);
         params.append('page', page.toString());
         params.append('size', size.toString());
         return apiRequest<Page<MarcacaoResponse>>(`/api/marcacoes/passadas?${params.toString()}`, {

--- a/src/services/api/utilizadores/utilizadoresApi.ts
+++ b/src/services/api/utilizadores/utilizadoresApi.ts
@@ -47,15 +47,18 @@ export const utilizadoresApi = {
             method: 'GET',
         }),
 
-    listarFuncionarios: () =>
-        apiRequest<UtilizadorResponseDTO[]>('/api/utilizadores/funcionarios', {
-            method: 'GET',
-        }),
+    listarFuncionarios: (nome?: string, tipo?: string, page = 0, size = 20) => {
+        const params = new URLSearchParams({ page: String(page), size: String(size) });
+        if (nome) params.append('nome', nome);
+        if (tipo) params.append('tipo', tipo);
+        return apiRequest<import('../core/client').Page<UtilizadorResponseDTO>>(`/api/utilizadores/funcionarios?${params}`);
+    },
 
-    listarUtentes: () =>
-        apiRequest<UtilizadorResponseDTO[]>('/api/utilizadores/utentes', {
-            method: 'GET',
-        }),
+    listarUtentes: (nome?: string, page = 0, size = 20) => {
+        const params = new URLSearchParams({ page: String(page), size: String(size) });
+        if (nome) params.append('nome', nome);
+        return apiRequest<import('../core/client').Page<UtilizadorResponseDTO>>(`/api/utilizadores/utentes?${params}`);
+    },
 
     aprovarFuncionario: (id: number) =>
         apiRequest<void>(`/api/utilizadores/${id}/aprovar`, {


### PR DESCRIPTION
Closes #128 (frontend part)

## O que foi feito

- `utilizadoresApi.listarFuncionarios/listarUtentes` aceitam agora `nome`, `page`, `size`
- `marcacoesApi.obterPassadas` aceita agora `assunto` e `nomeUtente`
- `UserManagement`: pesquisa com debounce (300ms) chama o servidor em vez de filtrar no cliente
- Remove `.filter()` no cliente para utentes e funcionários

## Summary by Sourcery

Implement server-side filtering and pagination support for user and appointment listings.

New Features:
- Allow listing of funcionarios and utentes with optional name filter and pagination parameters.
- Support filtering past appointments by subject and user name on the backend API.

Enhancements:
- Debounce secretary user search inputs and delegate filtering of users and utentes to server-side APIs instead of client-side filtering.