### PR TITLE
fix: UX defaults — tema claro, idioma PT e navegação pós-login/logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
     const stored = localStorage.getItem('theme');
     if (stored === 'dark') return true;
     if (stored === 'light') return false;
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return false; // default: light
   };
 
   const [registerInitialType, setRegisterInitialType] = useState<'user' | 'employee'>('user');
@@ -116,6 +116,11 @@ function App() {
   };
 
   const handleLogout = () => {
+    // Clear dashboard view history so next login starts at home page
+    localStorage.removeItem('secretaryDashboardViewHistory');
+    localStorage.removeItem('balnearioDashboardViewHistory');
+    localStorage.removeItem('escolaDashboardView');
+    localStorage.removeItem('internoDashboardView');
     logout();
     navigate('/login');
   };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -185,9 +185,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const handleLogoutState = () => {
     setUser(null);
     setIsAuthenticated(false);
-    localStorage.removeItem('user');
     localStorage.removeItem('lastActivity');
     localStorage.removeItem('token'); // Clear legacy token if exists
+    // Clear dashboard view history so next login starts at home page
+    localStorage.removeItem('secretaryDashboardViewHistory');
+    localStorage.removeItem('balnearioDashboardViewHistory');
+    localStorage.removeItem('escolaDashboardView');
+    localStorage.removeItem('internoDashboardView');
   };
 
   const login = async (identifier: string, password: string, type: 'funcionario' | 'utente') => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -15,7 +15,7 @@ void i18n
       escapeValue: false,
     },
     detection: {
-      order: ['localStorage', 'navigator'],
+      order: ['localStorage'],
       caches: ['localStorage'],
       lookupLocalStorage: 'app-language',
     },


### PR DESCRIPTION
Closes #115

## Alterações
- Tema claro como default (removido fallback para `prefers-color-scheme`)
- PT como idioma default (removido `navigator.language` da deteção i18n)
- Logout (manual ou por inatividade) limpa view history → próximo login vai para página inicial do role
- Reload mantém a página atual

## Summary by Sourcery

Set consistent UX defaults for theme, language, and post-authentication navigation behavior.

Bug Fixes:
- Ensure users always start from their role home page after logging in following a logout or inactivity timeout.

Enhancements:
- Set light theme as the default regardless of system color scheme preferences.
- Set Portuguese as the default language based solely on the stored app preference, ignoring browser language.
- Clear dashboard view history on logout to reset navigation state on next login while preserving current page on reload.