### PR TITLE
feat(email-opcional): checkbox 'Não possui email' na criação de utent…

### DIFF
--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -51,6 +51,7 @@ export function UserManagement() {
         birthDate: '',
     });
     const [emailSelection, setEmailSelection] = useState<'auto' | 'manual'>('auto');
+    const [noEmail, setNoEmail] = useState(false);
     const [errors, setErrors] = useState<Record<string, string>>({});
 
     // State for "User Exists" Dialog
@@ -341,6 +342,7 @@ export function UserManagement() {
             birthDate: '',
         });
         setEmailSelection('auto');
+        setNoEmail(false);
     };
 
     const checkNifExistence = async () => {
@@ -386,13 +388,15 @@ export function UserManagement() {
         }
 
         // Email
-        if (!formData.email) {
+        if (formData.role === 'UTENTE' && noEmail) {
+            // sem email — válido
+        } else if (!formData.email) {
             newErrors.email = t('auth.emailRequired');
         } else if (!validateEmail(formData.email)) {
             newErrors.email = t('auth.emailInvalid');
         }
         // Institutional Check
-        if (formData.role !== 'UTENTE' && !formData.email.endsWith('@florinhasdovouga.pt')) {
+        if (formData.role !== 'UTENTE' && formData.email && !formData.email.endsWith('@florinhasdovouga.pt')) {
             newErrors.email = t('auth.useInstitutionalEmail');
         }
 
@@ -432,16 +436,19 @@ export function UserManagement() {
             }
 
             // 4. Create Account
+            const emailToSend = (formData.role === 'UTENTE' && noEmail) ? undefined : formData.email;
             await utilizadoresApi.createBySecretary({
                 name: formData.name,
                 nif: formData.nif,
                 contact: formData.contact || undefined,
-                email: formData.email,
+                email: emailToSend,
                 birthDate: formData.birthDate,
                 isEmployee: formData.role !== 'UTENTE',
                 role: formData.role
             });
-            toast.success(t('userManagement.messages.accountCreatedWithEmail', { email: formData.email }));
+            toast.success(emailToSend
+                ? t('userManagement.messages.accountCreatedWithEmail', { email: emailToSend })
+                : 'Conta criada com sucesso (sem email)');
             handleClearCreate();
             fetchUsers();
         } catch (error: any) {
@@ -999,8 +1006,27 @@ export function UserManagement() {
                                             ) : (
                                                 <div className="space-y-3 pt-4 border-t border-border/40">
                                                     <Label className="text-sm font-bold opacity-80 pl-1 uppercase tracking-tight">{t('appointmentDialog.fields.email')}</Label>
-                                                    <Input type="email" placeholder="email@exemplo.pt" className={`h-11 bg-background/50 text-base rounded-xl ${errors.email ? 'border-status-error ring-status-error/20' : ''}`} value={formData.email} onChange={e => { setFormData({ ...formData, email: e.target.value }); if (errors.email) setErrors({ ...errors, email: '' }); }} />
-                                                    {errors.email && <p className="text-status-error text-xs font-bold pl-1">{errors.email}</p>}
+                                                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={noEmail}
+                                                            onChange={e => {
+                                                                setNoEmail(e.target.checked);
+                                                                if (e.target.checked) {
+                                                                    setFormData(prev => ({ ...prev, email: '' }));
+                                                                    setErrors(prev => ({ ...prev, email: '' }));
+                                                                }
+                                                            }}
+                                                            className="w-4 h-4 accent-primary"
+                                                        />
+                                                        <span className="text-sm text-muted-foreground">Não possui endereço de email</span>
+                                                    </label>
+                                                    {!noEmail && (
+                                                        <>
+                                                            <Input type="email" placeholder="email@exemplo.pt" className={`h-11 bg-background/50 text-base rounded-xl ${errors.email ? 'border-status-error ring-status-error/20' : ''}`} value={formData.email} onChange={e => { setFormData({ ...formData, email: e.target.value }); if (errors.email) setErrors({ ...errors, email: '' }); }} />
+                                                            {errors.email && <p className="text-status-error text-xs font-bold pl-1">{errors.email}</p>}
+                                                        </>
+                                                    )}
                                                 </div>
                                             )}
                                         </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -474,6 +474,9 @@ export function ProfilePage({ user, onBack, onUpdateUser, isDarkMode, isEmployee
                   {renderField('NIF', formData.nif, 'nif', false)}
                   {renderField(t('profile.birthDate'), formData.dateOfBirth, 'dateOfBirth', false)}
                   {renderField('Email', formData.email, 'email', false, t('profile.placeholders.emailUnavailable'), 'md:col-span-2')}
+                  <p className="md:col-span-2 text-xs text-muted-foreground italic pl-1">
+                    Para adicionar ou alterar o seu endereço de email, dirija-se à secretaria da instituição.
+                  </p>
                   {renderField(t('profile.phone'), formData.phonePersonal, 'phonePersonal', true, t('profile.placeholders.addContact'))}
                 </div>
               )}

--- a/src/services/api/utilizadores/utilizadoresApi.ts
+++ b/src/services/api/utilizadores/utilizadoresApi.ts
@@ -75,7 +75,7 @@ export const utilizadoresApi = {
         name: string;
         nif: string;
         contact?: string;
-        email: string;
+        email?: string;
         birthDate: string; // YYYY-MM-DD
         isEmployee: boolean;
         role?: string;


### PR DESCRIPTION
…e + aviso no perfil

- UserManagement: substituir campo email obrigatório por checkbox 'Não possui endereço de email' para utentes; campo email só aparece se checkbox não estiver marcado; validação e payload ajustados
- ProfilePage: mensagem informativa abaixo do campo email a indicar que alterações devem ser feitas na secretaria
- utilizadoresApi: email passa a ser opcional no tipo de createBySecretary

## Summary by Sourcery

Allow creating utente users without an email address and clarify how profile email changes must be requested.

New Features:
- Add a 'Não possui endereço de email' option in secretary user creation to allow utente accounts without an email.
- Show a profile page notice explaining that email additions or changes must be handled by the secretary.

Enhancements:
- Make email optional in the secretary createBySecretary API payload for utente users.