### PR TITLE
Make email optional with checkbox and alerts in user management

### DIFF
--- a/src/components/secretary/AppointmentDialog.tsx
+++ b/src/components/secretary/AppointmentDialog.tsx
@@ -353,7 +353,8 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
   };
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && requestClose()}>
+    <>
+      <Dialog open={open} onOpenChange={(isOpen) => !isOpen && requestClose()}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto bg-card border-border text-foreground">
         <DialogHeader>
           <DialogTitle className="text-foreground">{t('appointmentDialog.title')}</DialogTitle>
@@ -620,5 +621,6 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+    </>
   );
 }

--- a/src/components/secretary/AppointmentDialog.tsx
+++ b/src/components/secretary/AppointmentDialog.tsx
@@ -18,6 +18,16 @@ import { useTranslation } from 'react-i18next';
 import { useUnsavedChangesWarning } from '../../hooks/useUnsavedChangesWarning';
 import { UnsavedChangesModal } from '../shared/UnsavedChangesModal';
 import { PrivacyNotice } from '../shared/PrivacyNotice';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "../ui/alert-dialog";
 
 interface AppointmentDialogProps {
   open: boolean;
@@ -39,6 +49,8 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [pendingClose, setPendingClose] = useState(false);
   const [subjects, setSubjects] = useState<Assunto[]>([]);
+  const [noEmail, setNoEmail] = useState(false);
+  const [showNoEmailWarning, setShowNoEmailWarning] = useState(false);
 
   const [formData, setFormData] = useState({
     nif: '',
@@ -201,7 +213,9 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
     if (!nameValidation.valid) {
       newErrors.name = nameValidation.error || t('appointmentDialog.errors.nameInvalid');
     }
-    if (!formData.email.trim()) {
+    if (noEmail) {
+      // sem email — válido
+    } else if (!formData.email.trim()) {
       newErrors.email = t('appointmentDialog.errors.emailRequired');
     } else if (!validateEmail(formData.email)) {
       newErrors.email = t('appointmentDialog.errors.emailInvalid');
@@ -270,7 +284,7 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
         assunto: formData.subject,
         utenteNif: formData.nif,
         utenteNome: formData.name,
-        utenteEmail: formData.email,
+        utenteEmail: noEmail ? undefined : formData.email,
         utenteTelefone: formData.contact,
         utenteDataNasc: formData.dateOfBirth || undefined,
       };
@@ -309,6 +323,12 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
 
     if (!validateForm()) {
       toast.error(t('appointmentDialog.errors.fixForm'));
+      return;
+    }
+
+    // Mostrar aviso se está a criar conta sem email
+    if (noEmail && !originalUser && !showNoEmailWarning) {
+      setShowNoEmailWarning(true);
       return;
     }
 
@@ -429,17 +449,33 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
 
             <div className="space-y-2">
               <Label htmlFor="email" className="text-foreground">{t('appointmentDialog.fields.email')}</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder={t('appointmentDialog.fields.emailPlaceholder')}
-                value={formData.email}
-                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                aria-invalid={!!errors.email}
-                aria-describedby={errors.email ? 'email-error' : undefined}
-                className={`bg-card border-border text-foreground ${errors.email ? 'border-status-error' : ''}`}
-              />
-              {errors.email && <p id="email-error" className="text-sm text-status-error">{errors.email}</p>}
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={noEmail}
+                  onChange={e => {
+                    setNoEmail(e.target.checked);
+                    if (e.target.checked) { setFormData(prev => ({ ...prev, email: '' })); setErrors(prev => ({ ...prev, email: '' })); }
+                  }}
+                  className="w-4 h-4 accent-primary"
+                />
+                <span className="text-sm text-muted-foreground">Não possui endereço de email</span>
+              </label>
+              {!noEmail && (
+                <>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder={t('appointmentDialog.fields.emailPlaceholder')}
+                    value={formData.email}
+                    onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                    aria-invalid={!!errors.email}
+                    aria-describedby={errors.email ? 'email-error' : undefined}
+                    className={`bg-card border-border text-foreground ${errors.email ? 'border-status-error' : ''}`}
+                  />
+                  {errors.email && <p id="email-error" className="text-sm text-status-error">{errors.email}</p>}
+                </>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -562,5 +598,27 @@ export function AppointmentDialog({ open, onClose, onSuccess, date, time, funcio
         }}
       />
     </Dialog>
+
+    <AlertDialog open={showNoEmailWarning} onOpenChange={setShowNoEmailWarning}>
+      <AlertDialogContent className="bg-card border-border">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Criar conta sem email</AlertDialogTitle>
+          <AlertDialogDescription className="text-muted-foreground">
+            Está a criar uma conta <strong>sem endereço de email</strong>. Isto significa que o utente:
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>Não receberá notificações por email</li>
+              <li>Não poderá recuperar a password por email</li>
+              <li>A recuperação de conta será apenas presencial</li>
+            </ul>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={() => { setShowNoEmailWarning(false); document.querySelector<HTMLFormElement>('form')?.requestSubmit(); }}>
+            Confirmar e Criar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -52,6 +52,8 @@ export function UserManagement() {
     });
     const [emailSelection, setEmailSelection] = useState<'auto' | 'manual'>('auto');
     const [noEmail, setNoEmail] = useState(false);
+    const [showNoEmailWarning, setShowNoEmailWarning] = useState(false);
+    const noEmailConfirmedRef = useRef(false);
     const [errors, setErrors] = useState<Record<string, string>>({});
 
     // State for "User Exists" Dialog
@@ -343,6 +345,7 @@ export function UserManagement() {
         });
         setEmailSelection('auto');
         setNoEmail(false);
+        noEmailConfirmedRef.current = false;
     };
 
     const checkNifExistence = async () => {
@@ -436,6 +439,11 @@ export function UserManagement() {
             }
 
             // 4. Create Account
+            if (formData.role === 'UTENTE' && noEmail && !noEmailConfirmedRef.current) {
+                setShowNoEmailWarning(true);
+                return;
+            }
+            noEmailConfirmedRef.current = false;
             const emailToSend = (formData.role === 'UTENTE' && noEmail) ? undefined : formData.email;
             await utilizadoresApi.createBySecretary({
                 name: formData.name,
@@ -1493,6 +1501,28 @@ export function UserManagement() {
                     if (pendingClose) setPendingClose(false);
                 }}
             />
+
+            <AlertDialog open={showNoEmailWarning} onOpenChange={setShowNoEmailWarning}>
+                <AlertDialogContent className="bg-card border-border">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Criar conta sem email</AlertDialogTitle>
+                        <AlertDialogDescription className="text-muted-foreground">
+                            Está a criar uma conta <strong>sem endereço de email</strong>. Isto significa que o utente:
+                            <ul className="list-disc list-inside mt-2 space-y-1">
+                                <li>Não receberá notificações por email</li>
+                                <li>Não poderá recuperar a password por email</li>
+                                <li>A recuperação de conta será apenas presencial</li>
+                            </ul>
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={() => setShowNoEmailWarning(false)}>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { setShowNoEmailWarning(false); noEmailConfirmedRef.current = true; handleCreateSubmit(new Event('submit') as any); }}>
+                            Confirmar e Criar
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -51,6 +51,7 @@ export function UserManagement() {
         birthDate: '',
     });
     const [emailSelection, setEmailSelection] = useState<'auto' | 'manual'>('auto');
+    const [noEmail, setNoEmail] = useState(false);
     const [errors, setErrors] = useState<Record<string, string>>({});
 
     // State for "User Exists" Dialog
@@ -341,6 +342,7 @@ export function UserManagement() {
             birthDate: '',
         });
         setEmailSelection('auto');
+        setNoEmail(false);
     };
 
     const checkNifExistence = async () => {
@@ -386,13 +388,15 @@ export function UserManagement() {
         }
 
         // Email
-        if (!formData.email) {
+        if (formData.role === 'UTENTE' && noEmail) {
+            // sem email — válido
+        } else if (!formData.email) {
             newErrors.email = t('auth.emailRequired');
         } else if (!validateEmail(formData.email)) {
             newErrors.email = t('auth.emailInvalid');
         }
         // Institutional Check
-        if (formData.role !== 'UTENTE' && !formData.email.endsWith('@florinhasdovouga.pt')) {
+        if (formData.role !== 'UTENTE' && formData.email && !formData.email.endsWith('@florinhasdovouga.pt')) {
             newErrors.email = t('auth.useInstitutionalEmail');
         }
 
@@ -432,16 +436,19 @@ export function UserManagement() {
             }
 
             // 4. Create Account
+            const emailToSend = (formData.role === 'UTENTE' && noEmail) ? undefined : formData.email;
             await utilizadoresApi.createBySecretary({
                 name: formData.name,
                 nif: formData.nif,
                 contact: formData.contact || undefined,
-                email: formData.email,
+                email: emailToSend,
                 birthDate: formData.birthDate,
                 isEmployee: formData.role !== 'UTENTE',
                 role: formData.role
             });
-            toast.success(t('userManagement.messages.accountCreatedWithEmail', { email: formData.email }));
+            toast.success(emailToSend
+                ? t('userManagement.messages.accountCreatedWithEmail', { email: emailToSend })
+                : 'Conta criada com sucesso (sem email)');
             handleClearCreate();
             fetchUsers();
         } catch (error: any) {
@@ -999,8 +1006,27 @@ export function UserManagement() {
                                             ) : (
                                                 <div className="space-y-3 pt-4 border-t border-border/40">
                                                     <Label className="text-sm font-bold opacity-80 pl-1 uppercase tracking-tight">{t('appointmentDialog.fields.email')}</Label>
-                                                    <Input type="email" placeholder="email@exemplo.pt" className={`h-11 bg-background/50 text-base rounded-xl ${errors.email ? 'border-status-error ring-status-error/20' : ''}`} value={formData.email} onChange={e => { setFormData({ ...formData, email: e.target.value }); if (errors.email) setErrors({ ...errors, email: '' }); }} />
-                                                    {errors.email && <p className="text-status-error text-xs font-bold pl-1">{errors.email}</p>}
+                                                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={noEmail}
+                                                            onChange={e => {
+                                                                setNoEmail(e.target.checked);
+                                                                if (e.target.checked) {
+                                                                    setFormData(prev => ({ ...prev, email: '' }));
+                                                                    setErrors(prev => ({ ...prev, email: '' }));
+                                                                }
+                                                            }}
+                                                            className="w-4 h-4 accent-primary"
+                                                        />
+                                                        <span className="text-sm text-muted-foreground">Não possui endereço de email</span>
+                                                    </label>
+                                                    {!noEmail && (
+                                                        <>
+                                                            <Input type="email" placeholder="email@exemplo.pt" className={`h-11 bg-background/50 text-base rounded-xl ${errors.email ? 'border-status-error ring-status-error/20' : ''}`} value={formData.email} onChange={e => { setFormData({ ...formData, email: e.target.value }); if (errors.email) setErrors({ ...errors, email: '' }); }} />
+                                                            {errors.email && <p className="text-status-error text-xs font-bold pl-1">{errors.email}</p>}
+                                                        </>
+                                                    )}
                                                 </div>
                                             )}
                                         </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -474,6 +474,9 @@ export function ProfilePage({ user, onBack, onUpdateUser, isDarkMode, isEmployee
                   {renderField('NIF', formData.nif, 'nif', false)}
                   {renderField(t('profile.birthDate'), formData.dateOfBirth, 'dateOfBirth', false)}
                   {renderField('Email', formData.email, 'email', false, t('profile.placeholders.emailUnavailable'), 'md:col-span-2')}
+                  <p className="md:col-span-2 text-xs text-muted-foreground italic pl-1">
+                    Para adicionar ou alterar o seu endereço de email, dirija-se à secretaria da instituição.
+                  </p>
                   {renderField(t('profile.phone'), formData.phonePersonal, 'phonePersonal', true, t('profile.placeholders.addContact'))}
                 </div>
               )}

--- a/src/services/api/utilizadores/utilizadoresApi.ts
+++ b/src/services/api/utilizadores/utilizadoresApi.ts
@@ -75,7 +75,7 @@ export const utilizadoresApi = {
         name: string;
         nif: string;
         contact?: string;
-        email: string;
+        email?: string;
         birthDate: string; // YYYY-MM-DD
         isEmployee: boolean;
         role?: string;


### PR DESCRIPTION
This pull request introduces the ability to create user accounts without requiring an email address, primarily for "UTENTE" (patient) users, and ensures users are warned about the consequences of not providing an email. The changes affect both the appointment creation dialog and the user management page, updating validation, API calls, and user interface to handle the new "no email" option.

**Support for accounts without email:**

* Added a "Não possui endereço de email" checkbox to both the `AppointmentDialog` and `UserManagement` forms, allowing creation of accounts without an email address. When checked, the email field is hidden and validation is bypassed for email. [[1]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728R52-R53) [[2]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728R453-R466) [[3]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728R478-R479) [[4]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R54-R56) [[5]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R347-R348) [[6]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R1017-R1037)
* Updated validation logic to treat the absence of email as valid when the "no email" option is selected for "UTENTE" users. [[1]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728L204-R218) [[2]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029L389-R402)

**User warnings and confirmation:**

* Introduced an `AlertDialog` confirmation modal that warns users about the implications of creating an account without an email (e.g., no notifications, no password recovery, only in-person account recovery). The modal must be confirmed before proceeding. [[1]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728R329-R334) [[2]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728R602-R624) [[3]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R442-R459) [[4]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R1504-R1525)

**API and data model updates:**

* Updated the API request payloads and types to make the `email` field optional, sending `undefined` if no email is provided. [[1]](diffhunk://#diff-5bf651e1548d81f1793ac872acfa2fd3aa06ee21ea83cdfefa6260ff2ef70728L273-R287) [[2]](diffhunk://#diff-8fd43afd3789d324c482ac55da8c210a2897a41296064ac37f7769e06ee6b029R442-R459) [[3]](diffhunk://#diff-5178067363d1e10afccacf3dc39c18e2b6ac4c6ff475f043a118a9518e63b2b1L78-R78)

**User experience improvements:**

* On the profile page, added a note clarifying that email changes/additions must be handled in person at the institution's secretary.

These changes ensure the system can accommodate users without email addresses while maintaining clear communication about the limitations this entails.

## Summary by Sourcery

Allow creating and managing UTENTE accounts without an email address while warning staff about its implications.

New Features:
- Add a 'no email' option to appointment and user management forms to create UTENTE accounts without an email address.
- Introduce confirmation dialogs explaining the consequences of creating accounts without email before submission.

Enhancements:
- Make email optional in user creation API payloads and propagate this through secretary flows.
- Clarify on the profile page that email changes must be handled in person at the institution secretary.