### PR TITLE
feat(otp-presencial): botão 'Gerar Código Presencial' na recuperação …

### DIFF
--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -578,6 +578,16 @@ export function UserManagement() {
         }
     };
 
+    const handleGeneratePresentialCode = async () => {
+        if (!recoverData.foundUser) return;
+        try {
+            const result = await utilizadoresApi.generatePresentialCode(recoverData.foundUser.nif);
+            toast.success(`Código presencial gerado: ${result.code}`, { duration: 30000 });
+        } catch (error: any) {
+            toast.error(error.message || 'Erro ao gerar código presencial');
+        }
+    };
+
     // Server-side filtering: users/utentes already filtered by searchQuery
     const filteredUsers = users;
     const filteredUtentesList = utentes;
@@ -1118,10 +1128,16 @@ export function UserManagement() {
                                                     </div>
                                                 </div>
 
-                                                <Button type="submit" className="w-full h-12 bg-amber-500 hover:bg-amber-600 text-white text-base font-bold rounded-xl shadow-lg shadow-amber-500/20 transition-all">
-                                                    <Send className="w-5 h-5 mr-3" />
-                                                    Atualizar e Enviar Acesso
-                                                </Button>
+                                                <div className="flex gap-3">
+                                                    <Button type="submit" className="flex-1 h-12 bg-amber-500 hover:bg-amber-600 text-white text-base font-bold rounded-xl shadow-lg shadow-amber-500/20 transition-all">
+                                                        <Send className="w-5 h-5 mr-3" />
+                                                        Atualizar e Enviar Acesso
+                                                    </Button>
+                                                    <Button type="button" onClick={handleGeneratePresentialCode} className="flex-1 h-12 bg-primary hover:bg-primary/90 text-white text-base font-bold rounded-xl shadow-lg shadow-primary/20 transition-all">
+                                                        <Lock className="w-5 h-5 mr-3" />
+                                                        Gerar Código Presencial
+                                                    </Button>
+                                                </div>
                                             </div>
                                         )}
                                     </form>

--- a/src/components/secretary/UserManagement.tsx
+++ b/src/components/secretary/UserManagement.tsx
@@ -1129,10 +1129,12 @@ export function UserManagement() {
                                                 </div>
 
                                                 <div className="flex gap-3">
-                                                    <Button type="submit" className="flex-1 h-12 bg-amber-500 hover:bg-amber-600 text-white text-base font-bold rounded-xl shadow-lg shadow-amber-500/20 transition-all">
-                                                        <Send className="w-5 h-5 mr-3" />
-                                                        Atualizar e Enviar Acesso
-                                                    </Button>
+                                                    {recoverData.email && (
+                                                        <Button type="submit" className="flex-1 h-12 bg-amber-500 hover:bg-amber-600 text-white text-base font-bold rounded-xl shadow-lg shadow-amber-500/20 transition-all">
+                                                            <Send className="w-5 h-5 mr-3" />
+                                                            Atualizar e Enviar Acesso
+                                                        </Button>
+                                                    )}
                                                     <Button type="button" onClick={handleGeneratePresentialCode} className="flex-1 h-12 bg-primary hover:bg-primary/90 text-white text-base font-bold rounded-xl shadow-lg shadow-primary/20 transition-all">
                                                         <Lock className="w-5 h-5 mr-3" />
                                                         Gerar Código Presencial

--- a/src/services/api/utilizadores/utilizadoresApi.ts
+++ b/src/services/api/utilizadores/utilizadoresApi.ts
@@ -95,6 +95,12 @@ export const utilizadoresApi = {
             body: JSON.stringify(data),
         }),
 
+    generatePresentialCode: (nif: string) =>
+        apiRequest<{ code: string }>('/api/utilizadores/generate-presential-code', {
+            method: 'POST',
+            body: JSON.stringify({ nif }),
+        }),
+
     // Direito ao Esquecimento (RGPD Art.º 17)
     solicitarEliminacao: () =>
         apiRequest<void>('/api/utilizadores/me/delete-request', {


### PR DESCRIPTION
…de conta

- utilizadoresApi: novo método generatePresentialCode
- UserManagement: botão 'Gerar Código Presencial' ao lado de 'Atualizar e Enviar Acesso'; mostra código em toast com duração 30s

## Summary by Sourcery

Add support in user recovery for generating and displaying a one-time presential access code.

New Features:
- Introduce a utilizadores API endpoint wrapper to generate a presential code for a user by NIF.
- Add a 'Gerar Código Presencial' button in the user recovery UI that calls the API and shows the generated code in a toast notification.