### PR TITLE
Feat/periodicidade requisicoes

### DIFF
--- a/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
+++ b/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
@@ -326,6 +326,32 @@ export function RequisitionDetailsDialog({
               </div>
             </div>
 
+            {/* Periodicidade */}
+            <div className="border-t border-border pt-6 space-y-3">
+              <div className="flex items-center gap-3">
+                <h3 className="text-xs font-black text-muted-foreground uppercase tracking-widest whitespace-nowrap">{t('requisitions.periodica.label')}</h3>
+                <div className="h-px bg-border w-full" />
+              </div>
+              {selectedRequisicao.periodicaFrequencia ? (
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-1">
+                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.frequencia.label')}</p>
+                    <p className="text-sm font-semibold text-foreground">{t(`requisitions.periodica.frequencia.${selectedRequisicao.periodicaFrequencia}`)}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataInicio')}</p>
+                    <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataInicio ? new Date(selectedRequisicao.periodicaDataInicio).toLocaleDateString(locale) : '—'}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataFim')}</p>
+                    <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataFim ? new Date(selectedRequisicao.periodicaDataFim).toLocaleDateString(locale) : 'Sem data final'}</p>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground italic">Não periódica</p>
+              )}
+            </div>
+
             {/* Ações de Gestão */}
             {canManageRequests && (
               <div className="border-t border-border pt-6 space-y-4">

--- a/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
+++ b/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
@@ -335,30 +335,32 @@ export function RequisitionDetailsDialog({
                 <div className="h-px bg-border w-full" />
               </div>
               {selectedRequisicao.periodicaFrequencia ? (
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <div className="space-y-1">
-                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.frequencia.label')}</p>
-                    <p className="text-sm font-semibold text-foreground">{t(`requisitions.periodica.frequencia.${selectedRequisicao.periodicaFrequencia}`)}</p>
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="space-y-1">
+                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.frequencia.label')}</p>
+                      <p className="text-sm font-semibold text-foreground">{t(`requisitions.periodica.frequencia.${selectedRequisicao.periodicaFrequencia}`)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataInicio')}</p>
+                      <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataInicio ? new Date(selectedRequisicao.periodicaDataInicio).toLocaleDateString(locale) : '—'}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataFim')}</p>
+                      <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataFim ? new Date(selectedRequisicao.periodicaDataFim).toLocaleDateString(locale) : 'Sem data final'}</p>
+                    </div>
                   </div>
-                  <div className="space-y-1">
-                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataInicio')}</p>
-                    <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataInicio ? new Date(selectedRequisicao.periodicaDataInicio).toLocaleDateString(locale) : '—'}</p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">{t('requisitions.periodica.dataFim')}</p>
-                    <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataFim ? new Date(selectedRequisicao.periodicaDataFim).toLocaleDateString(locale) : 'Sem data final'}</p>
-                  </div>
-                </div>
-                {canManageRequests && onCancelPeriodicidade && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="mt-3 text-destructive border-destructive/30 hover:bg-destructive/10"
-                    onClick={() => onCancelPeriodicidade(selectedRequisicao.id)}
-                  >
-                    Cancelar Periodicidade
-                  </Button>
-                )}
+                  {canManageRequests && onCancelPeriodicidade && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mt-3 text-destructive border-destructive/30 hover:bg-destructive/10"
+                      onClick={() => onCancelPeriodicidade(selectedRequisicao.id)}
+                    >
+                      Cancelar Periodicidade
+                    </Button>
+                  )}
+                </>
               ) : (
                 <p className="text-sm text-muted-foreground italic">Não periódica</p>
               )}

--- a/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
+++ b/src/components/shared/requisitions/RequisitionDetailsDialog.tsx
@@ -26,6 +26,7 @@ interface RequisitionDetailsDialogProps {
   updatingEstadoId: number | null;
   onClose: () => void;
   onSaveStatus: () => void;
+  onCancelPeriodicidade?: (id: number) => void;
   locale: string;
   t: (key: string) => string;
 }
@@ -42,6 +43,7 @@ export function RequisitionDetailsDialog({
   updatingEstadoId,
   onClose,
   onSaveStatus,
+  onCancelPeriodicidade,
   locale,
   t,
 }: Readonly<RequisitionDetailsDialogProps>) {
@@ -347,6 +349,16 @@ export function RequisitionDetailsDialog({
                     <p className="text-sm font-semibold text-foreground">{selectedRequisicao.periodicaDataFim ? new Date(selectedRequisicao.periodicaDataFim).toLocaleDateString(locale) : 'Sem data final'}</p>
                   </div>
                 </div>
+                {canManageRequests && onCancelPeriodicidade && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-3 text-destructive border-destructive/30 hover:bg-destructive/10"
+                    onClick={() => onCancelPeriodicidade(selectedRequisicao.id)}
+                  >
+                    Cancelar Periodicidade
+                  </Button>
+                )}
               ) : (
                 <p className="text-sm text-muted-foreground italic">Não periódica</p>
               )}

--- a/src/pages/requisitions/SharedRequisitionsPage.tsx
+++ b/src/pages/requisitions/SharedRequisitionsPage.tsx
@@ -1582,6 +1582,11 @@ export function SharedRequisitionsPage({
         updatingEstadoId={updatingEstadoId}
         onClose={() => setOpenedRequisicaoId(null)}
         onSaveStatus={handleAtualizarEstado}
+        onCancelPeriodicidade={async (id) => {
+          await requisicoesApi.cancelarPeriodicidade(id);
+          fetchRequisicoes();
+          setOpenedRequisicaoId(null);
+        }}
         locale={locale}
         t={t}
       />

--- a/src/services/api/requisicoes/requisicoesApi.ts
+++ b/src/services/api/requisicoes/requisicoesApi.ts
@@ -147,4 +147,9 @@ export const requisicoesApi = {
       method: 'PATCH',
       body: JSON.stringify(payload),
     }),
+
+  cancelarPeriodicidade: (id: number) =>
+    apiRequest<RequisicaoResponse>(`/api/requisicoes/${id}/periodicidade`, {
+      method: 'DELETE',
+    }),
 };

--- a/src/services/api/requisicoes/types.ts
+++ b/src/services/api/requisicoes/types.ts
@@ -127,6 +127,9 @@ export interface RequisicaoResponse {
   numeroPassageiros?: number;
   condutor?: string | null;
   assunto?: string | null;
+  periodicaFrequencia?: PeriodicidadeFrequencia | null;
+  periodicaDataInicio?: string | null;
+  periodicaDataFim?: string | null;
 }
 
 export interface RequisicaoFilters {


### PR DESCRIPTION
This pull request adds support for managing and displaying periodic (recurring) requisitions in the requisitions UI. The main changes include updating the requisition details dialog to show periodicity information, providing a button to cancel periodicity, updating the API service to support this operation, and extending the requisition data model with periodicity fields.

**UI Enhancements for Periodic Requisitions:**

* The `RequisitionDetailsDialog` component now displays periodicity information (frequency, start date, end date) for requisitions that are periodic, and shows a "Cancelar Periodicidade" button for users with management permissions.
* The dialog's props and usage have been updated to support an optional `onCancelPeriodicidade` callback. [[1]](diffhunk://#diff-66051aa401c66399fe7a0f6f103dce21cc34d8eb015ba2e07689172210853343R29) [[2]](diffhunk://#diff-66051aa401c66399fe7a0f6f103dce21cc34d8eb015ba2e07689172210853343R46)

**API and Data Model Updates:**

* The `requisicoesApi` service now includes a `cancelarPeriodicidade` method, which sends a DELETE request to cancel a requisition's periodicity.
* The `RequisicaoResponse` interface has been extended to include `periodicaFrequencia`, `periodicaDataInicio`, and `periodicaDataFim` fields.

**Integration:**

* The `SharedRequisitionsPage` now wires up the new `onCancelPeriodicidade` handler, ensuring the UI and data are refreshed after cancellation.

## Summary by Sourcery

Add support for viewing and cancelling periodic requisitions in the requisition details UI and API.

New Features:
- Display periodicity information (frequency and start/end dates) in the requisition details dialog when a requisition is periodic.
- Allow users with management permissions to cancel a requisition's periodicity from the details dialog.

Enhancements:
- Extend the requisition API client and response type to handle periodicity fields and a cancel-periodicity operation.
- Wire the shared requisitions page to use the new cancel periodicity API and refresh data after cancellation.