### PR TITLE
refactor: delegate report email body to backend

### DIFF
--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -204,9 +204,8 @@ export function ReportsPage() {
         const validEmails = emails.filter(e => e.trim()).join(',');
         const pdfBase64 = doc.output('datauristring');
         const filename = getReportFilename();
-        const subject = `Relatório Institucional - Florinhas do Vouga (${formatDatePt(startDate)} a ${formatDatePt(endDate)})`;
         const seccoes = Array.from(selected);
-        await reportsApi.sendByEmail({ to: validEmails, subject, pdfBase64, fileName: filename, periodoInicio: formatDatePt(startDate), periodoFim: formatDatePt(endDate), seccoes });
+        await reportsApi.sendByEmail({ to: validEmails, pdfBase64, fileName: filename, periodoInicio: startDate, periodoFim: endDate, seccoes });
         toast.success('Relatório enviado por email');
       } else {
         doc.save(getReportFilename());

--- a/src/pages/secretary/ReportsPage.tsx
+++ b/src/pages/secretary/ReportsPage.tsx
@@ -205,8 +205,8 @@ export function ReportsPage() {
         const pdfBase64 = doc.output('datauristring');
         const filename = getReportFilename();
         const subject = `Relatório Institucional - Florinhas do Vouga (${formatDatePt(startDate)} a ${formatDatePt(endDate)})`;
-        const body = `Segue em anexo o relatório institucional referente ao período de ${formatDatePt(startDate)} até ${formatDatePt(endDate)}.`;
-        await reportsApi.sendByEmail({ to: validEmails, subject, body, pdfBase64, fileName: filename });
+        const seccoes = Array.from(selected);
+        await reportsApi.sendByEmail({ to: validEmails, subject, pdfBase64, fileName: filename, periodoInicio: formatDatePt(startDate), periodoFim: formatDatePt(endDate), seccoes });
         toast.success('Relatório enviado por email');
       } else {
         doc.save(getReportFilename());

--- a/src/services/api/reports/reportsApi.ts
+++ b/src/services/api/reports/reportsApi.ts
@@ -3,9 +3,11 @@ import { apiRequest } from '../core/client';
 export interface SendReportRequest {
   to: String;
   subject: String;
-  body: String;
   pdfBase64?: String;
   fileName?: String;
+  periodoInicio?: String;
+  periodoFim?: String;
+  seccoes?: String[];
 }
 
 export interface RelatorioPeriodico {

--- a/src/services/api/reports/reportsApi.ts
+++ b/src/services/api/reports/reportsApi.ts
@@ -1,13 +1,13 @@
 import { apiRequest } from '../core/client';
 
 export interface SendReportRequest {
-  to: String;
-  subject: String;
-  pdfBase64?: String;
-  fileName?: String;
-  periodoInicio?: String;
-  periodoFim?: String;
-  seccoes?: String[];
+  to: string;
+  subject: string;
+  pdfBase64?: string;
+  fileName?: string;
+  periodoInicio: string;
+  periodoFim: string;
+  seccoes: string[];
 }
 
 export interface RelatorioPeriodico {

--- a/src/services/api/reports/reportsApi.ts
+++ b/src/services/api/reports/reportsApi.ts
@@ -2,7 +2,6 @@ import { apiRequest } from '../core/client';
 
 export interface SendReportRequest {
   to: string;
-  subject: string;
   pdfBase64?: string;
   fileName?: string;
   periodoInicio: string;


### PR DESCRIPTION
## Resumo
- Frontend envia secções selecionadas e período ao backend em vez de construir o body do email localmente
- Uniformiza a abordagem: todos os textos de email são definidos no backend

## Dependência
- Requer merge do PR backend fix/emails primeiro

## Summary by Sourcery

Enhancements:
- Update report email sending to pass selected sections and reporting period metadata to the backend instead of a pre-built email body.