### PR TITLE
Fix/balneario stock

### DIFF
--- a/src/components/balneario/BalnearioAppointmentDetailsDialog.tsx
+++ b/src/components/balneario/BalnearioAppointmentDetailsDialog.tsx
@@ -71,6 +71,7 @@ export function BalnearioAppointmentDetailsDialog({
     const [stockLevels, setStockLevels] = useState<Record<string, StockCheckResult>>({});
     const [shoeSizeStock, setShoeSizeStock] = useState<StockCheckResult | null>(null);
     const [showStockWarning, setShowStockWarning] = useState(false);
+    const [armazemItems, setArmazemItems] = useState<{id: number; nome: string}[]>([]);
 
     // Initialize editable state from appointment data whenever dialog opens or appointment changes
     useEffect(() => {
@@ -102,6 +103,7 @@ export function BalnearioAppointmentDetailsDialog({
         // Fetch stock levels
         const allItems = [...HYGIENE_OPTIONS, ...LAUNDRY_OPTIONS, ...CLOTHING_OPTIONS].map(o => o.value);
         armazemApi.verificarStock(allItems).then(setStockLevels).catch(() => {});
+        armazemApi.listarTodos().then(setArmazemItems).catch(() => {});
     }, [open, appointment]);
 
     const toggleOption = (option: string) => {
@@ -173,10 +175,12 @@ export function BalnearioAppointmentDetailsDialog({
             const roupasVal = allOptions
                 .filter(opt => selectedOptions[opt])
                 .map(opt => {
+                    const matchedItem = armazemItems.find(i => i.nome === opt);
                     if (opt === 'Sapatos/Sapatilhas' && shoeSize) {
-                        return { categoria: opt, tamanho: shoeSize, quantidade: 1 };
+                        const shoeItem = armazemItems.find(i => i.nome === shoeSize);
+                        return { categoria: opt, tamanho: shoeSize, quantidade: 1, itemId: shoeItem?.id };
                     }
-                    return { categoria: opt, quantidade: 1 };
+                    return { categoria: opt, quantidade: 1, itemId: matchedItem?.id };
                 });
 
             await marcacoesApi.atualizarDetalhesBalneario(parseInt(appointment.id), {


### PR DESCRIPTION
This pull request enhances the `BalnearioAppointmentDetailsDialog` component by improving how item data is handled and saved, particularly by associating item IDs from the warehouse (`armazem`) with selected options and ensuring that save operations are validated before updating appointment states. The changes improve data integrity and user experience when managing appointment details.

**Improvements to item handling and data integrity:**

* The dialog now fetches and stores a list of all warehouse items (`armazemItems`) on load, enabling the association of item IDs with selected options. [[1]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fR74) [[2]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fR106)
* When preparing clothing and shoe data to save, the code now includes the corresponding `itemId` from `armazemItems` for each selected option, ensuring that updates are tied to the correct inventory items.

**Enhancements to save and state update logic:**

* The `handleSaveDetails` function now returns a boolean indicating success or failure, and the dialog checks this return value before proceeding to update the appointment state to 'CONCLUIDO' or 'EM_PROGRESSO', preventing state updates if saving fails. [[1]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fL160-R165) [[2]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fR203-R207) [[3]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fR241-R244) [[4]](diffhunk://#diff-d818863cf91dd8aa78776d5061f011adcd7b6b8f45384291cf190851ca9f993fR294-R297)

## Summary by Sourcery

Improve Balneario appointment details dialog to associate saved items with warehouse inventory and prevent state changes when saving fails.

New Features:
- Store the full list of warehouse items in the appointment details dialog to allow linking selections to inventory entries.

Bug Fixes:
- Include corresponding warehouse item IDs when saving clothing and shoe selections to ensure they map to the correct stock items.
- Block appointment state transitions to 'CONCLUIDO' or 'EM_PROGRESSO' when saving details fails or required shoe size is missing.